### PR TITLE
Add description to metadata.

### DIFF
--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/entity/SpecificationEntity.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/entity/SpecificationEntity.kt
@@ -12,6 +12,7 @@ import javax.persistence.Id
 data class SpecificationEntity(
     @Id @GeneratedValue val id: UUID,
     val title: String,
+    @Column(columnDefinition = "TEXT") val description: String?,
     val version: String,
     @Column(columnDefinition = "TEXT") val content: String,
     val remoteAddress: String?
@@ -22,6 +23,7 @@ data class SpecificationEntity(
             SpecificationEntity(
                 specification.id,
                 specification.title,
+                specification.description,
                 specification.version.version,
                 specification.content,
                 specification.remoteAddress
@@ -31,6 +33,7 @@ data class SpecificationEntity(
     fun toDomain(): Specification = Specification(
         this.id,
         this.title,
+        this.description,
         Version(this.version),
         this.content,
         this.remoteAddress

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationDto.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationDto.kt
@@ -5,6 +5,7 @@ import java.util.UUID
 data class SpecificationDto(
     val id: UUID,
     val title: String,
+    val description: String?,
     val version: String,
     val content: String,
     val remoteAddress: String?

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationConverter.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationConverter.kt
@@ -31,9 +31,11 @@ class SpecificationConverter constructor(
 
         val content = specificationDataService.parseFileContent(fileContent)
         val uuid = specificationFileDto.id ?: UUID.randomUUID()
+
         return Specification(
             uuid,
             specificationDataService.readTitle(content),
+            specificationDataService.readDescription(content),
             Version(specificationDataService.readVersion(content)),
             content,
             specificationFileDto.fileUrl

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
@@ -48,16 +48,23 @@ class SpecificationDataService @Autowired constructor(
     fun readTitle(json: String): String {
         try {
             return JsonPath.read<String>(json, "$.info.title")
-        } catch (exc: PathNotFoundException) {
-            throw IllegalArgumentException("No title given in content.")
+        } catch (exception: PathNotFoundException) {
+            throw IllegalArgumentException("No title given in content.", exception)
         }
     }
 
     fun readVersion(json: String): String {
         try {
             return JsonPath.read<String>(json, "$.info.version")
-        } catch (exc: PathNotFoundException) {
-            throw IllegalArgumentException("No version given in content.")
+        } catch (exception: PathNotFoundException) {
+            throw IllegalArgumentException("No version given in content.", exception)
         }
     }
+
+    fun readDescription(json: String): String? =
+        try {
+            JsonPath.read<String>(json, "$.info.description")
+        } catch (exception: PathNotFoundException) {
+            null
+        }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SynchronizationService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SynchronizationService.kt
@@ -24,6 +24,7 @@ class SynchronizationService constructor(
         val newSpecification = Specification(
             specification.id,
             specificationDataService.readTitle(content),
+            specificationDataService.readDescription(content),
             Version(specificationDataService.readVersion(content)),
             content,
             specification.remoteAddress

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Specification.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Specification.kt
@@ -5,6 +5,7 @@ import java.util.UUID
 data class Specification(
     val id: UUID,
     val title: String,
+    val description: String?,
     val version: Version,
     val content: String,
     val remoteAddress: String?

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/database/SpecificationEntityUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/database/SpecificationEntityUnitTest.kt
@@ -19,6 +19,7 @@ internal class SpecificationEntityUnitTest {
         val specification = Specification(
             UUID.fromString(SPEC_UUID),
             "Spec",
+            "Description",
             Version("1.0.0"),
             JSON_CONTENT,
             null
@@ -30,6 +31,7 @@ internal class SpecificationEntityUnitTest {
             SpecificationEntity(
                 UUID.fromString(SPEC_UUID),
                 "Spec",
+                "Description",
                 "1.0.0",
                 JSON_CONTENT,
                 null

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerUnitTest.kt
@@ -17,7 +17,7 @@ internal class SpecificationControllerUnitTest {
 
     companion object {
         const val SWAGGER_SPECIFICATION =
-            "{\"swagger\": \"2.0\", \"info\": {\"version\": \"1.0.0\",\"title\": \"Swagger Petstore\"}}"
+            "{\"swagger\": \"2.0\", \"info\": {\"version\": \"1.0.0\",\"title\": \"Swagger Petstore\",\"description\":\"Description\"}}"
         const val UUID_STRING = "65d8491f-e602-40fc-a595-45e75f690df1"
     }
 
@@ -42,6 +42,7 @@ internal class SpecificationControllerUnitTest {
         val specification = Specification(
             UUID.fromString(UUID_STRING),
             "Swagger Petstore",
+            "Description",
             Version("1.0.0"),
             SWAGGER_SPECIFICATION,
             null
@@ -49,6 +50,7 @@ internal class SpecificationControllerUnitTest {
         val specificationDto = SpecificationDto(
             UUID.fromString(UUID_STRING),
             "Swagger Petstore",
+            "Description",
             "1.0.0",
             SWAGGER_SPECIFICATION,
             null
@@ -73,6 +75,7 @@ internal class SpecificationControllerUnitTest {
         val specification = Specification(
             UUID.fromString(UUID_STRING),
             "Swagger Petstore",
+            "Description",
             Version("1.0.0"),
             SWAGGER_SPECIFICATION,
             null
@@ -80,6 +83,7 @@ internal class SpecificationControllerUnitTest {
         val specificationDto = SpecificationDto(
             UUID.fromString(UUID_STRING),
             "Swagger Petstore",
+            "Description",
             "1.0.0",
             SWAGGER_SPECIFICATION,
             null
@@ -96,6 +100,7 @@ internal class SpecificationControllerUnitTest {
             SpecificationDto(
                 UUID.fromString(UUID_STRING),
                 "Swagger Petstore",
+                "Description",
                 "1.0.0",
                 SWAGGER_SPECIFICATION,
                 null
@@ -110,6 +115,7 @@ internal class SpecificationControllerUnitTest {
         val specification = Specification(
             uuid,
             "Test",
+            "Description",
             Version("v2"),
             SWAGGER_SPECIFICATION,
             "http://swaggerpetstore.com/docs"
@@ -117,6 +123,7 @@ internal class SpecificationControllerUnitTest {
         val specificationDto = SpecificationDto(
             uuid,
             "Test",
+            "Description",
             "v2",
             SWAGGER_SPECIFICATION,
             "http://swaggerpetstore.com/docs"
@@ -129,6 +136,7 @@ internal class SpecificationControllerUnitTest {
                 Specification(
                     uuid,
                     "Test",
+                    "Description",
                     Version("v2"),
                     SWAGGER_SPECIFICATION,
                     "http://swaggerpetstore.com/docs"
@@ -139,6 +147,7 @@ internal class SpecificationControllerUnitTest {
         assertThat(specificationController.findAllSpecifications()).containsOnly(
             SpecificationDto(
                 uuid, "Test",
+                "Description",
                 "v2",
                 SWAGGER_SPECIFICATION,
                 "http://swaggerpetstore.com/docs"

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationConverterTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationConverterTest.kt
@@ -14,7 +14,7 @@ class SpecificationConverterTest {
 
     companion object {
         const val SWAGGER_SPECIFICATION =
-            "{\"swagger\": \"2.0\", \"info\": {\"version\": \"1.0.0\",\"title\": \"Swagger Petstore\"}}"
+            "{\"swagger\": \"2.0\", \"info\": {\"version\": \"1.0.0\",\"title\": \"Swagger Petstore\",\"description\":\"Description\"}}"
         const val SWAGGER_REMOTE = "https://swagger.com/remote/file.json"
     }
 
@@ -43,6 +43,7 @@ class SpecificationConverterTest {
         val expectedSpecification = Specification(
             specification.id,
             "Swagger Petstore",
+            "Description",
             Version("1.0.0"),
             SWAGGER_SPECIFICATION,
             ""
@@ -75,6 +76,7 @@ class SpecificationConverterTest {
         val expectedSpecification = Specification(
             specification.id,
             "Swagger Petstore",
+            "Description",
             Version("1.0.0"),
             SWAGGER_SPECIFICATION,
             SWAGGER_REMOTE

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataServiceTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataServiceTest.kt
@@ -19,10 +19,12 @@ class SpecificationDataServiceTest {
 
     companion object {
         const val SWAGGER_SPECIFICATION =
-            "{\"swagger\": \"2.0\", \"info\": {\"version\": \"1.0.0\",\"title\": \"Swagger Petstore\"}}"
+            "{\"swagger\": \"2.0\", \"info\": {\"version\": \"1.0.0\",\"title\": \"Swagger Petstore\",\"description\": \"My Description\"}}"
         const val SWAGGER_SPECIFICATION_NOTITLE = "{\"swagger\": \"2.0\", \"info\": {\"version\": \"1.0.0\"}}"
         const val SWAGGER_SPECIFICATION_NOVERSION =
             "{\"swagger\": \"2.0\", \"info\": {\"title\": \"Swagger Petstore\"}}"
+        const val SWAGGER_SPECIFICATION_NODESCRIPTION =
+            "{\"swagger\": \"2.0\", \"info\": {\"title\": \"Swagger Petstore\",\"version\": \"1.0.0\"}}"
         const val YAML_SPECIFICATION = "openapi: \"3.0.0\"\r\ninfo:\r\n  version: 1.0.0\r\n  title: Swagger Petstore"
     }
 
@@ -44,6 +46,11 @@ class SpecificationDataServiceTest {
     }
 
     @Test
+    fun readDescription_shouldReturnDescription() {
+        assertThat(specificationDataService.readDescription(SWAGGER_SPECIFICATION)).isEqualTo("My Description")
+    }
+
+    @Test
     fun readTitle_shouldFailWhenNoTitleIsGiven() {
         assertThatThrownBy { specificationDataService.readTitle(SWAGGER_SPECIFICATION_NOTITLE) }.isInstanceOf(
             IllegalArgumentException::class.java
@@ -55,6 +62,11 @@ class SpecificationDataServiceTest {
         assertThatThrownBy { specificationDataService.readVersion(SWAGGER_SPECIFICATION_NOVERSION) }.isInstanceOf(
             IllegalArgumentException::class.java
         ).hasMessage("No version given in content.")
+    }
+
+    @Test
+    fun readDescription_shouldReturnNullWhenNoDescriptionIsGiven() {
+        assertThat(specificationDataService.readDescription(SWAGGER_SPECIFICATION_NODESCRIPTION)).isEqualTo(null)
     }
 
     @Test

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataServiceTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataServiceTest.kt
@@ -20,10 +20,10 @@ class SpecificationDataServiceTest {
     companion object {
         const val SWAGGER_SPECIFICATION =
             "{\"swagger\": \"2.0\", \"info\": {\"version\": \"1.0.0\",\"title\": \"Swagger Petstore\",\"description\": \"My Description\"}}"
-        const val SWAGGER_SPECIFICATION_NOTITLE = "{\"swagger\": \"2.0\", \"info\": {\"version\": \"1.0.0\"}}"
-        const val SWAGGER_SPECIFICATION_NOVERSION =
+        const val SWAGGER_SPECIFICATION_WITHOUT_TITLE = "{\"swagger\": \"2.0\", \"info\": {\"version\": \"1.0.0\"}}"
+        const val SWAGGER_SPECIFICATION_WITHOUT_VERSION =
             "{\"swagger\": \"2.0\", \"info\": {\"title\": \"Swagger Petstore\"}}"
-        const val SWAGGER_SPECIFICATION_NODESCRIPTION =
+        const val SWAGGER_SPECIFICATION_WITHOUT_DESCRIPTION =
             "{\"swagger\": \"2.0\", \"info\": {\"title\": \"Swagger Petstore\",\"version\": \"1.0.0\"}}"
         const val YAML_SPECIFICATION = "openapi: \"3.0.0\"\r\ninfo:\r\n  version: 1.0.0\r\n  title: Swagger Petstore"
     }
@@ -52,21 +52,21 @@ class SpecificationDataServiceTest {
 
     @Test
     fun readTitle_shouldFailWhenNoTitleIsGiven() {
-        assertThatThrownBy { specificationDataService.readTitle(SWAGGER_SPECIFICATION_NOTITLE) }.isInstanceOf(
+        assertThatThrownBy { specificationDataService.readTitle(SWAGGER_SPECIFICATION_WITHOUT_TITLE) }.isInstanceOf(
             IllegalArgumentException::class.java
         ).hasMessage("No title given in content.")
     }
 
     @Test
     fun readVersion_shouldFailWhenNoVersionIsGiven() {
-        assertThatThrownBy { specificationDataService.readVersion(SWAGGER_SPECIFICATION_NOVERSION) }.isInstanceOf(
+        assertThatThrownBy { specificationDataService.readVersion(SWAGGER_SPECIFICATION_WITHOUT_VERSION) }.isInstanceOf(
             IllegalArgumentException::class.java
         ).hasMessage("No version given in content.")
     }
 
     @Test
     fun readDescription_shouldReturnNullWhenNoDescriptionIsGiven() {
-        assertThat(specificationDataService.readDescription(SWAGGER_SPECIFICATION_NODESCRIPTION)).isEqualTo(null)
+        assertThat(specificationDataService.readDescription(SWAGGER_SPECIFICATION_WITHOUT_DESCRIPTION)).isNull()
     }
 
     @Test

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SynchronizationServiceTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SynchronizationServiceTest.kt
@@ -25,7 +25,7 @@ class SynchronizationServiceTest {
         const val SWAGGER_SPECIFICATION =
             "{\"swagger\": \"2.0\", \"info\": {\"version\": \"1.0.0\",\"title\": \"Swagger Petstore\", \"description\": \"Description\"}}"
         const val UPDATED_SWAGGER_SPECIFICATION =
-            "{\"swagger\": \"2.0\", \"info\": {\"version\": \"2.0.0\",\"title\": \"Swagger Petstore 2\", \"description\": \"Description\"}}"
+            "{\"swagger\": \"2.0\", \"info\": {\"version\": \"2.0.0\",\"title\": \"Swagger Petstore 2\", \"description\": \"Updated Description\"}}"
         const val REMOTE_ADDRESS = "http://testapi.com/testapi.json"
     }
 

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SynchronizationServiceTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SynchronizationServiceTest.kt
@@ -23,9 +23,9 @@ class SynchronizationServiceTest {
     companion object {
         const val SPECIFICATION_ID = "ff9da045-05f7-4f3d-9801-da609086935c"
         const val SWAGGER_SPECIFICATION =
-            "{\"swagger\": \"2.0\", \"info\": {\"version\": \"1.0.0\",\"title\": \"Swagger Petstore\"}}"
+            "{\"swagger\": \"2.0\", \"info\": {\"version\": \"1.0.0\",\"title\": \"Swagger Petstore\", \"description\": \"Description\"}}"
         const val UPDATED_SWAGGER_SPECIFICATION =
-            "{\"swagger\": \"2.0\", \"info\": {\"version\": \"2.0.0\",\"title\": \"Swagger Petstore 2\"}}"
+            "{\"swagger\": \"2.0\", \"info\": {\"version\": \"2.0.0\",\"title\": \"Swagger Petstore 2\", \"description\": \"Description\"}}"
         const val REMOTE_ADDRESS = "http://testapi.com/testapi.json"
     }
 
@@ -34,6 +34,7 @@ class SynchronizationServiceTest {
         val specification = Specification(
             UUID.fromString(SPECIFICATION_ID),
             "Swagger Petstore",
+            "Description",
             Version("1.0.0"),
             SWAGGER_SPECIFICATION,
             REMOTE_ADDRESS
@@ -41,6 +42,7 @@ class SynchronizationServiceTest {
         val updatedSpecification = Specification(
             UUID.fromString(SPECIFICATION_ID),
             "Swagger Petstore 2",
+            "Description",
             Version("2.0.0"),
             UPDATED_SWAGGER_SPECIFICATION,
             REMOTE_ADDRESS
@@ -53,6 +55,7 @@ class SynchronizationServiceTest {
         )
         given(specificationDataService.readTitle(UPDATED_SWAGGER_SPECIFICATION)).willReturn("Swagger Petstore 2")
         given(specificationDataService.readVersion(UPDATED_SWAGGER_SPECIFICATION)).willReturn("2.0.0")
+        given(specificationDataService.readDescription(UPDATED_SWAGGER_SPECIFICATION)).willReturn("Description")
 
         synchronizationService.synchronize(UUID.fromString(SPECIFICATION_ID))
 

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/service/SpecificationDatabaseServiceUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/service/SpecificationDatabaseServiceUnitTest.kt
@@ -27,6 +27,7 @@ internal class SpecificationDatabaseServiceUnitTest {
         val specification = Specification(
             UUID.fromString("e33dc111-3dd6-40f4-9c54-a64f6b10ab49"),
             "Spec",
+            "Description",
             Version("1.0.0"),
             "{\"json\": \"true\"}",
             "http://swaggerpetstore.com/docs"
@@ -35,6 +36,7 @@ internal class SpecificationDatabaseServiceUnitTest {
         val specificationEntity = SpecificationEntity(
             UUID.fromString("e33dc111-3dd6-40f4-9c54-a64f6b10ab49"),
             "Spec",
+            "Description",
             "1.0.0",
             "{\"json\": \"true\"}",
             "http://swaggerpetstore.com/docs"

--- a/backend/src/test/resources/data.sql
+++ b/backend/src/test/resources/data.sql
@@ -1,3 +1,3 @@
-INSERT INTO SPECIFICATION_ENTITY VALUES ('b6b06513d2594fafb34ba216b3daad6a', '{\"info\": {\"title\": \"Spec1\",  \"version\": \"v1\"}}', 'remoteUrl', 'Spec1', 'v1');
-INSERT INTO SPECIFICATION_ENTITY VALUES ('f67cb0a6c31b424bbfbbab0e163955ca', '{\"info\": {\"title\": \"Spec2\",  \"version\": \"v2\"}}', 'remoteUrl', 'Spec2', 'v2');
-INSERT INTO SPECIFICATION_ENTITY VALUES ('af0502a2741040e490fd3504f67de1ee', '{\"info\": {\"title\": \"Spec3\",  \"version\": \"v3\"}}', 'remoteUrl', 'Spec3', 'v3');
+INSERT INTO SPECIFICATION_ENTITY VALUES ('b6b06513d2594fafb34ba216b3daad6a', '{\"info\": {\"title\": \"Spec1\",  \"version\": \"v1\", \"description\": \"Description\"}}', 'remoteUrl', 'Description', 'Spec1', 'v1');
+INSERT INTO SPECIFICATION_ENTITY VALUES ('f67cb0a6c31b424bbfbbab0e163955ca', '{\"info\": {\"title\": \"Spec2\",  \"version\": \"v2\", \"description\": \"Description\"}}', 'remoteUrl', 'Description', 'Spec2', 'v2');
+INSERT INTO SPECIFICATION_ENTITY VALUES ('af0502a2741040e490fd3504f67de1ee', '{\"info\": {\"title\": \"Spec3\",  \"version\": \"v3\", \"description\": \"Description\"}}', 'remoteUrl', 'Description', 'Spec3', 'v3');


### PR DESCRIPTION
Parse the description from the OpenAPI-Specification and store it as metadata of the specification in ApiCenter.

Signed-off-by: Alexander Kaserbacher <alexander.kaserbacher@tngtech.com>