### PR TITLE
Add api definition

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -54,7 +54,6 @@ dependencies {
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.6"
     compile "com.jayway.jsonpath:json-path:2.4.0"
     compile "org.apache.commons:commons-io:1.3.2"
-    compile "io.springfox:springfox-swagger2:2.9.2"
     compile "net.rakugakibox.spring.boot:orika-spring-boot-starter:1.8.0"
     compile "org.hibernate:hibernate-search-orm:5.10.3.Final"
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/WebConfiguration.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/WebConfiguration.kt
@@ -4,15 +4,8 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
-import springfox.documentation.builders.ApiInfoBuilder
-import springfox.documentation.builders.PathSelectors
-import springfox.documentation.builders.RequestHandlerSelectors
-import springfox.documentation.spi.DocumentationType
-import springfox.documentation.spring.web.plugins.Docket
-import springfox.documentation.swagger2.annotations.EnableSwagger2
 
 @Configuration
-@EnableSwagger2
 class WebConfiguration {
 
     @Bean
@@ -23,18 +16,4 @@ class WebConfiguration {
             }
         }
     }
-
-    @Bean
-    fun docket(): Docket = Docket(DocumentationType.SWAGGER_2)
-        .select()
-        .apis(RequestHandlerSelectors.any())
-        .paths(PathSelectors.any())
-        .build()
-        .apiInfo(apiMetadata())
-
-    private fun apiMetadata() = ApiInfoBuilder()
-        .title("ApiCenter REST API")
-        .description("REST API for ApiCenter - a repository for all your OpenAPI specifications")
-        .license("Apache License Version 2.0, January 2004")
-        .build()
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
@@ -5,8 +5,6 @@ import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileDto
 import com.tngtech.apicenter.backend.connector.rest.mapper.SpecificationMapper
 import com.tngtech.apicenter.backend.connector.rest.service.SynchronizationService
 import com.tngtech.apicenter.backend.domain.handler.SpecificationHandler
-import io.swagger.annotations.Api
-import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -22,7 +20,6 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/specifications")
-@Api(description = "Operations to create, update and maintain specifications")
 class SpecificationController @Autowired constructor(
     private val specificationHandler: SpecificationHandler,
     private val synchronizationService: SynchronizationService,
@@ -31,7 +28,6 @@ class SpecificationController @Autowired constructor(
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    @ApiOperation("Upload a new specification, or define a remote specification by its url")
     fun uploadSpecification(@RequestBody specificationFileDto: SpecificationFileDto): SpecificationDto {
         val specification = specificationMapper.toDomain(specificationFileDto)
 
@@ -41,7 +37,6 @@ class SpecificationController @Autowired constructor(
     }
 
     @PutMapping("/{specificationId}")
-    @ApiOperation("Update an existing specification")
     fun updateSpecification(@RequestBody specificationFileDto: SpecificationFileDto, @PathVariable specificationId: String): SpecificationDto {
 
         val specification = specificationMapper.toDomain(
@@ -58,29 +53,24 @@ class SpecificationController @Autowired constructor(
     }
 
     @GetMapping
-    @ApiOperation("List all existing specifications")
     fun findAllSpecifications(): List<SpecificationDto> =
         specificationHandler.findAll().map { spec -> specificationMapper.fromDomain(spec) }
 
     @GetMapping("/{specificationId}")
-    @ApiOperation("Find a specific specification by id")
     fun findSpecification(@PathVariable specificationId: UUID): SpecificationDto =
         specificationMapper.fromDomain(specificationHandler.findOne(specificationId)!!)
 
     @DeleteMapping("/{specificationId}")
-    @ApiOperation("Delete a specification by id")
     fun deleteSpecification(@PathVariable specificationId: UUID) {
         specificationHandler.delete(specificationId)
     }
 
     @PostMapping("/{specificationId}/synchronize")
-    @ApiOperation("Synchronize an existing specification with its remote source")
     fun synchronizeSpecification(@PathVariable specificationId: UUID) {
         synchronizationService.synchronize(specificationId)
     }
 
     @GetMapping("/search/{searchString}")
-    @ApiOperation("Search for specifications by a search string")
     fun searchSpecification(@PathVariable searchString: String): List<SpecificationDto> =
         specificationHandler.search(searchString).map { spec -> specificationMapper.fromDomain(spec) }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationFileDto.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationFileDto.kt
@@ -1,13 +1,10 @@
 package com.tngtech.apicenter.backend.connector.rest.dto
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import io.swagger.annotations.ApiModel
-import io.swagger.annotations.ApiModelProperty
 import java.util.UUID
 
-@ApiModel(description = "Represents an OpenAPI-File")
 data class SpecificationFileDto @JsonCreator constructor(
-    @ApiModelProperty("The content of a file to be uploaded - either this or fileUrl has to be set.") val fileContent: String?,
-    @ApiModelProperty("The url of a remote file to be loaded - either this or fileContent has to be set.") val fileUrl: String? = "",
-    @ApiModelProperty(value = "The uuid of an already existing specification (optional)", required = false) val id: UUID? = null
+    val fileContent: String?,
+    val fileUrl: String? = "",
+    val id: UUID? = null
 )

--- a/backend/src/main/resources/api-definition.json
+++ b/backend/src/main/resources/api-definition.json
@@ -30,10 +30,14 @@
         "responses": {
           "200": {
             "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/SpecificationDto"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SpecificationDto"
+                  }
+                }
               }
             }
           },
@@ -62,18 +66,28 @@
           {
             "in": "body",
             "name": "specificationFileDto",
-            "description": "specificationFileDto",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/SpecificationFileDto"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/RemoteSpecificationFileDto"
+                },
+                {
+                  "$ref": "#/components/schemas/LocalSpecificationFileDto"
+                }
+              ]
             }
           }
         ],
         "responses": {
           "201": {
             "description": "Created",
-            "schema": {
-              "$ref": "#/definitions/SpecificationDto"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpecificationDto"
+                }
+              }
             }
           },
           "403": {
@@ -108,10 +122,14 @@
         "responses": {
           "200": {
             "description": "OK",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/SpecificationDto"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SpecificationDto"
+                  }
+                }
               }
             }
           },
@@ -148,8 +166,12 @@
         "responses": {
           "200": {
             "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/SpecificationDto"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpecificationDto"
+                }
+              }
             }
           },
           "403": {
@@ -180,7 +202,14 @@
             "description": "specificationFileDto",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/SpecificationFileDto"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/LocalSpecificationFileDto"
+                },
+                {
+                  "$ref": "#/components/schemas/RemoteSpecificationFileDto"
+                }
+              ]
             }
           },
           {
@@ -194,8 +223,12 @@
         "responses": {
           "200": {
             "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/SpecificationDto"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpecificationDto"
+                }
+              }
             }
           },
           "201": {
@@ -284,51 +317,74 @@
       }
     }
   },
-  "definitions": {
-    "SpecificationDto": {
-      "type": "object",
-      "properties": {
-        "content": {
-          "type": "string"
+  "components": {
+    "schemas": {
+      "SpecificationDto": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "remoteAddress": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
         },
-        "description": {
-          "type": "string"
+        "title": "SpecificationDto"
+      },
+      "SpecificationFileDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The uuid of an already existing specification",
+            "required": false
+          }
         },
-        "id": {
-          "type": "string",
-          "format": "uuid"
-        },
-        "remoteAddress": {
-          "type": "string"
-        },
-        "title": {
-          "type": "string"
-        },
-        "version": {
-          "type": "string"
+        "title": "SpecificationFileDto",
+        "description": "Represents an OpenAPI-File"
+      },
+      "RemoteSpecificationFileDto": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SpecificationFileDto"
+          }
+        ],
+        "properties": {
+          "fileUrl": {
+            "type": "string",
+            "description": "The url of a remote file to be loaded.",
+            "required": true
+          }
         }
       },
-      "title": "SpecificationDto"
-    },
-    "SpecificationFileDto": {
-      "type": "object",
-      "properties": {
-        "fileContent": {
-          "type": "string",
-          "description": "The content of a file to be uploaded - either this or fileUrl has to be set."
-        },
-        "fileUrl": {
-          "type": "string",
-          "description": "The url of a remote file to be loaded - either this or fileContent has to be set."
-        },
-        "id": {
-          "type": "string",
-          "format": "uuid",
-          "description": "The uuid of an already existing specification (optional)"
+      "LocalSpecificationFileDto": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SpecificationFileDto"
+          }
+        ],
+        "properties": {
+          "fileContent": {
+            "type": "string",
+            "description": "The content of a file to be uploaded.",
+            "required": true
+          }
         }
-      },
-      "title": "SpecificationFileDto",
-      "description": "Represents an OpenAPI-File"
+      }
     }
   }
 }

--- a/backend/src/main/resources/api-definition.json
+++ b/backend/src/main/resources/api-definition.json
@@ -1,0 +1,355 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "REST API for ApiCenter - a repository for all your OpenAPI specifications",
+    "version": "1.0.0",
+    "title": "ApiCenter REST API",
+    "license": {
+      "name": "Apache License Version 2.0, January 2004"
+    }
+  },
+  "host": "localhost:8080",
+  "basePath": "/",
+  "tags": [
+    {
+      "name": "specification-controller",
+      "description": "Operations to create, update and maintain specifications"
+    }
+  ],
+  "paths": {
+    "/specifications": {
+      "get": {
+        "tags": [
+          "specification-controller"
+        ],
+        "summary": "List all existing specifications",
+        "operationId": "findAllSpecificationsUsingGET",
+        "produces": [
+          "*/*"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SpecificationDto"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      },
+      "post": {
+        "tags": [
+          "specification-controller"
+        ],
+        "summary": "Upload a new specification, or define a remote specification by its url",
+        "operationId": "uploadSpecificationUsingPOST",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "specificationFileDto",
+            "description": "specificationFileDto",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SpecificationFileDto"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/SpecificationDto"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/specifications/search/{searchString}": {
+      "get": {
+        "tags": [
+          "specification-controller"
+        ],
+        "summary": "Search for specifications by a search string",
+        "operationId": "searchSpecificationUsingGET",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "searchString",
+            "in": "path",
+            "description": "searchString",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SpecificationDto"
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/specifications/{specificationId}": {
+      "get": {
+        "tags": [
+          "specification-controller"
+        ],
+        "summary": "Find a specific specification by id",
+        "operationId": "findSpecificationUsingGET",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "specificationId",
+            "in": "path",
+            "description": "specificationId",
+            "required": true,
+            "type": "string",
+            "format": "uuid"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/SpecificationDto"
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      },
+      "put": {
+        "tags": [
+          "specification-controller"
+        ],
+        "summary": "Update an existing specification",
+        "operationId": "updateSpecificationUsingPUT",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "specificationFileDto",
+            "description": "specificationFileDto",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SpecificationFileDto"
+            }
+          },
+          {
+            "name": "specificationId",
+            "in": "path",
+            "description": "specificationId",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/SpecificationDto"
+            }
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      },
+      "delete": {
+        "tags": [
+          "specification-controller"
+        ],
+        "summary": "Delete a specification by id",
+        "operationId": "deleteSpecificationUsingDELETE",
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "specificationId",
+            "in": "path",
+            "description": "specificationId",
+            "required": true,
+            "type": "string",
+            "format": "uuid"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "deprecated": false
+      }
+    },
+    "/specifications/{specificationId}/synchronize": {
+      "post": {
+        "tags": [
+          "specification-controller"
+        ],
+        "summary": "Synchronize an existing specification with its remote source",
+        "operationId": "synchronizeSpecificationUsingPOST",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "*/*"
+        ],
+        "parameters": [
+          {
+            "name": "specificationId",
+            "in": "path",
+            "description": "specificationId",
+            "required": true,
+            "type": "string",
+            "format": "uuid"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "201": {
+            "description": "Created"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "definitions": {
+    "SpecificationDto": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "remoteAddress": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "title": "SpecificationDto"
+    },
+    "SpecificationFileDto": {
+      "type": "object",
+      "properties": {
+        "fileContent": {
+          "type": "string",
+          "description": "The content of a file to be uploaded - either this or fileUrl has to be set."
+        },
+        "fileUrl": {
+          "type": "string",
+          "description": "The url of a remote file to be loaded - either this or fileContent has to be set."
+        },
+        "id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "The uuid of an already existing specification (optional)"
+        }
+      },
+      "title": "SpecificationFileDto",
+      "description": "Represents an OpenAPI-File"
+    }
+  }
+}

--- a/backend/src/main/resources/api-definition.json
+++ b/backend/src/main/resources/api-definition.json
@@ -37,9 +37,6 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
-          },
           "403": {
             "description": "Forbidden"
           },
@@ -78,9 +75,6 @@
             "schema": {
               "$ref": "#/definitions/SpecificationDto"
             }
-          },
-          "401": {
-            "description": "Unauthorized"
           },
           "403": {
             "description": "Forbidden"
@@ -121,9 +115,6 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
-          },
           "403": {
             "description": "Forbidden"
           },
@@ -160,9 +151,6 @@
             "schema": {
               "$ref": "#/definitions/SpecificationDto"
             }
-          },
-          "401": {
-            "description": "Unauthorized"
           },
           "403": {
             "description": "Forbidden"
@@ -213,9 +201,6 @@
           "201": {
             "description": "Created"
           },
-          "401": {
-            "description": "Unauthorized"
-          },
           "403": {
             "description": "Forbidden"
           },
@@ -250,9 +235,6 @@
           },
           "204": {
             "description": "No Content"
-          },
-          "401": {
-            "description": "Unauthorized"
           },
           "403": {
             "description": "Forbidden"
@@ -290,9 +272,6 @@
           },
           "201": {
             "description": "Created"
-          },
-          "401": {
-            "description": "Unauthorized"
           },
           "403": {
             "description": "Forbidden"


### PR DESCRIPTION
Removes Springfox and all annotations for OpenAPI-Documentation in controllers and DTOs - and adds an explicit OpenAPI-File.