### PR TITLE
Set request URL for combined and separate builds

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -45,6 +45,14 @@
                   "with": "src/environments/environment.prod.ts"
                 }
               ]
+            },
+            "mono": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.mono.ts"
+                }
+              ]
             }
           }
         },
@@ -56,6 +64,9 @@
           "configurations": {
             "production": {
               "browserTarget": "frontend:build:production"
+            },
+            "mono": {
+
             }
           }
         },

--- a/frontend/build.gradle
+++ b/frontend/build.gradle
@@ -10,7 +10,7 @@ node {
 
 task buildClientDev(type: NpmTask, dependsOn: 'npmInstall') {
   description = 'Compiles Angular assets'
-  args = ['run', 'build', '--prod=false']
+  args = ['run', 'build', '-c=mono'] // overrides the environment, which makes requests to window.location.origin
 }
 
 task copyFrontendFiles(type: Copy) {
@@ -23,5 +23,5 @@ copyFrontendFiles.mustRunAfter(buildClientDev)
 
 task ngServe(type: NpmTask, dependsOn: 'npmInstall') {
   description = 'Compiles, serves and watches Angular assets'
-  args = ['run', 'start']
+  args = ['run', 'start'] // uses the default environment, which makes requests to localhost:8080
 }

--- a/frontend/src/environments/environment.mono.ts
+++ b/frontend/src/environments/environment.mono.ts
@@ -1,4 +1,4 @@
 export const environment = {
-  production: true,
+  production: false,
   apiUrl: window.location.origin
 };


### PR DESCRIPTION
HTTP requests made to the backend now use an address sourced from `window.location.origin` instead of a hardcoded `localhost`.

This alone would work for the single build, local and remote, because the requests are sent to the same base URL. However when run seperately (and hence, locally), this is wrong, because Angular's location is on port 4200, and the requests need to go to 8080 (Spring)

Signed-off-by: Philippa Hack <philippa.hack@tngtech.com>