### PR TITLE
Correct specification route

### DIFF
--- a/frontend/src/app/specification-search-detail/specification-search-detail.component.html
+++ b/frontend/src/app/specification-search-detail/specification-search-detail.component.html
@@ -7,7 +7,7 @@
   <div class="row top-buffer">
     <div class="col">
       <div *ngFor="let specification of specifications">
-        <div><p class="lead"><a [routerLink]="['/specifications', specification.id]" routerLinkActive="active">{{ specification.title }}</a></p></div>
+        <div><p class="lead"><a [routerLink]="['/specifications', specification.id, specification.versions[0].version]" routerLinkActive="active">{{ specification.title }}</a></p></div>
         <div><p class="small">{{ specification.description != null && specification.description.length > 100 ? (specification.description | slice:0:100) + ' ...' : specification.description }}</p></div>
       </div>
     </div>


### PR DESCRIPTION
After clicking around the website, it seems that there was never an
Angular route configured for `specifications/:specificationId`. However in
the specification search, this was the router link used when a user
clicked on a specification matching the search string. As Angular had no
route configured, clicking just returned the webapp to the home route
('/').

This change replaces that non-existent route with the page of the most
recent version of the specification.

Signed-off-by: Philippa Hack <philippa.hack@tngtech.com>