### PR TITLE
API and Angular Routing fixes

### DIFF
--- a/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerIntegrationTest.kt
+++ b/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerIntegrationTest.kt
@@ -42,6 +42,26 @@ internal class SpecificationControllerIntegrationTest {
     }
 
     @Test
+    fun findAllSpecifications_requiresAuthentication() {
+        mockMvc.perform(get("/api/1.0/specifications"))
+                .andExpect(status().`is`(403))
+    }
+
+    @Test
+    fun findOneSpecification_shouldGetOne() {
+        mockMvc.perform(get("/api/1.0/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a").with(user("user")))
+                .andExpect(status().isOk)
+                .andExpect(content().contentType("application/json;charset=UTF-8"))
+                .andExpect(jsonPath("title", equalTo("Spec1")))
+    }
+
+    @Test
+    fun findOneSpecification_shouldGracefullyFail() {
+        mockMvc.perform(get("/api/1.0/specifications/af0502a2-7410-40e4-90fd-3504f67de1ef").with(user("user")))
+                .andExpect(status().`is`(404))
+    }
+
+    @Test
     fun uploadSpecification_shouldCreateSpecification() {
         mockMvc.perform(
             post("/api/1.0/specifications")

--- a/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerIntegrationTest.kt
+++ b/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerIntegrationTest.kt
@@ -28,7 +28,7 @@ internal class SpecificationControllerIntegrationTest {
 
     @Test
     fun findAllSpecifications_shouldReturnAllSpecifications() {
-        mockMvc.perform(get("/api/1.0/specifications").with(user("user")))
+        mockMvc.perform(get("/api/v1/specifications").with(user("user")))
             .andExpect(status().isOk)
             .andExpect(content().contentType("application/json;charset=UTF-8"))
             .andExpect(jsonPath("$[0].title", equalTo("Spec1")))
@@ -43,13 +43,13 @@ internal class SpecificationControllerIntegrationTest {
 
     @Test
     fun findAllSpecifications_requiresAuthentication() {
-        mockMvc.perform(get("/api/1.0/specifications"))
-                .andExpect(status().`is`(403))
+        mockMvc.perform(get("/api/v1/specifications"))
+                .andExpect(status().isForbidden)
     }
 
     @Test
     fun findOneSpecification_shouldGetOne() {
-        mockMvc.perform(get("/api/1.0/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a").with(user("user")))
+        mockMvc.perform(get("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a").with(user("user")))
                 .andExpect(status().isOk)
                 .andExpect(content().contentType("application/json;charset=UTF-8"))
                 .andExpect(jsonPath("title", equalTo("Spec1")))
@@ -57,14 +57,14 @@ internal class SpecificationControllerIntegrationTest {
 
     @Test
     fun findOneSpecification_shouldGracefullyFail() {
-        mockMvc.perform(get("/api/1.0/specifications/af0502a2-7410-40e4-90fd-3504f67de1ef").with(user("user")))
-                .andExpect(status().`is`(404))
+        mockMvc.perform(get("/api/v1/specifications/af0502a2-7410-40e4-90fd-3504f67de1ef").with(user("user")))
+                .andExpect(status().isNotFound)
     }
 
     @Test
     fun uploadSpecification_shouldCreateSpecification() {
         mockMvc.perform(
-            post("/api/1.0/specifications")
+            post("/api/v1/specifications")
                 .with(user("user"))
                 .with(csrf())
                 .contentType("application/json")
@@ -84,7 +84,7 @@ internal class SpecificationControllerIntegrationTest {
     @Test
     fun uploadSpecification_shouldCreateSpecificationFromYaml() {
         mockMvc.perform(
-            post("/api/1.0/specifications")
+            post("/api/v1/specifications")
                 .with(user("user"))
                 .with(csrf())
                 .contentType("application/json")
@@ -104,7 +104,7 @@ internal class SpecificationControllerIntegrationTest {
     @Test
     fun uploadSpecification_shouldCreateNewVersion() {
         mockMvc.perform(
-            post("/api/1.0/specifications")
+            post("/api/v1/specifications")
                 .with(user("user"))
                 .with(csrf())
                 .contentType("application/json")
@@ -121,7 +121,7 @@ internal class SpecificationControllerIntegrationTest {
             .andExpect(jsonPath("$.versions[0].version", equalTo("v2")))
 
         mockMvc.perform(
-            get("/api/1.0/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a")
+            get("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a")
                 .with(user("user"))
                 .with(csrf())
         )
@@ -133,7 +133,7 @@ internal class SpecificationControllerIntegrationTest {
     @Test
     fun updateSpecification_shouldUpdateSpecification() {
         mockMvc.perform(
-            put("/api/1.0/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a")
+            put("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a")
                 .with(user("user"))
                 .with(csrf())
                 .contentType("application/json")
@@ -151,7 +151,7 @@ internal class SpecificationControllerIntegrationTest {
             .andExpect(jsonPath("$.versions[0].version", equalTo("vX")))
 
         mockMvc.perform(
-            get("/api/1.0/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a").with(user("user"))
+            get("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a").with(user("user"))
         )
             .andExpect(jsonPath("$.title", equalTo("NewSpec")))
             .andExpect(jsonPath("$.versions[0].version", equalTo("vX")))
@@ -160,7 +160,7 @@ internal class SpecificationControllerIntegrationTest {
     @Test
     fun deleteSpecification_shouldDeleteSpecification() {
         mockMvc.perform(
-            delete("/api/1.0/specifications/af0502a2-7410-40e4-90fd-3504f67de1ee")
+            delete("/api/v1/specifications/af0502a2-7410-40e4-90fd-3504f67de1ee")
                 .with(user("user"))
                 .with(csrf())
         )

--- a/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerIntegrationTest.kt
+++ b/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerIntegrationTest.kt
@@ -28,7 +28,7 @@ internal class SpecificationControllerIntegrationTest {
 
     @Test
     fun findAllSpecifications_shouldReturnAllSpecifications() {
-        mockMvc.perform(get("/specifications").with(user("user")))
+        mockMvc.perform(get("/api/1.0/specifications").with(user("user")))
             .andExpect(status().isOk)
             .andExpect(content().contentType("application/json;charset=UTF-8"))
             .andExpect(jsonPath("$[0].title", equalTo("Spec1")))
@@ -44,7 +44,7 @@ internal class SpecificationControllerIntegrationTest {
     @Test
     fun uploadSpecification_shouldCreateSpecification() {
         mockMvc.perform(
-            post("/specifications")
+            post("/api/1.0/specifications")
                 .with(user("user"))
                 .with(csrf())
                 .contentType("application/json")
@@ -64,7 +64,7 @@ internal class SpecificationControllerIntegrationTest {
     @Test
     fun uploadSpecification_shouldCreateSpecificationFromYaml() {
         mockMvc.perform(
-            post("/specifications")
+            post("/api/1.0/specifications")
                 .with(user("user"))
                 .with(csrf())
                 .contentType("application/json")
@@ -84,7 +84,7 @@ internal class SpecificationControllerIntegrationTest {
     @Test
     fun uploadSpecification_shouldCreateNewVersion() {
         mockMvc.perform(
-            post("/specifications")
+            post("/api/1.0/specifications")
                 .with(user("user"))
                 .with(csrf())
                 .contentType("application/json")
@@ -101,7 +101,7 @@ internal class SpecificationControllerIntegrationTest {
             .andExpect(jsonPath("$.versions[0].version", equalTo("v2")))
 
         mockMvc.perform(
-            get("/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a")
+            get("/api/1.0/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a")
                 .with(user("user"))
                 .with(csrf())
         )
@@ -113,7 +113,7 @@ internal class SpecificationControllerIntegrationTest {
     @Test
     fun updateSpecification_shouldUpdateSpecification() {
         mockMvc.perform(
-            put("/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a")
+            put("/api/1.0/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a")
                 .with(user("user"))
                 .with(csrf())
                 .contentType("application/json")
@@ -131,7 +131,7 @@ internal class SpecificationControllerIntegrationTest {
             .andExpect(jsonPath("$.versions[0].version", equalTo("vX")))
 
         mockMvc.perform(
-            get("/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a").with(user("user"))
+            get("/api/1.0/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a").with(user("user"))
         )
             .andExpect(jsonPath("$.title", equalTo("NewSpec")))
             .andExpect(jsonPath("$.versions[0].version", equalTo("vX")))
@@ -140,7 +140,7 @@ internal class SpecificationControllerIntegrationTest {
     @Test
     fun deleteSpecification_shouldDeleteSpecification() {
         mockMvc.perform(
-            delete("/specifications/af0502a2-7410-40e4-90fd-3504f67de1ee")
+            delete("/api/1.0/specifications/af0502a2-7410-40e4-90fd-3504f67de1ee")
                 .with(user("user"))
                 .with(csrf())
         )

--- a/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionControllerIntegrationTest.kt
+++ b/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionControllerIntegrationTest.kt
@@ -24,7 +24,7 @@ class VersionControllerIntegrationTest {
 
     @Test
     fun findOneVersion_shouldReturnVersion() {
-        mockMvc.perform(get("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/v1")
+        mockMvc.perform(get("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/versions/v1")
             .with(user("user"))
             .with(csrf()))
             .andExpect(jsonPath("$.version", equalTo("v1")))
@@ -32,7 +32,7 @@ class VersionControllerIntegrationTest {
 
     @Test
     fun findOneVersion_shouldReturnJson() {
-        mockMvc.perform(get("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/v1")
+        mockMvc.perform(get("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/versions/v1")
                 .header("Accept", "application/json")
                 .with(user("user"))
                 .with(csrf()))
@@ -41,7 +41,7 @@ class VersionControllerIntegrationTest {
 
     @Test
     fun findOneVersion_shouldReturnYaml() {
-        mockMvc.perform(get("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/v1")
+        mockMvc.perform(get("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/versions/v1")
                 .header("Accept", "application/yml")
                 .with(user("user"))
                 .with(csrf()))
@@ -50,7 +50,7 @@ class VersionControllerIntegrationTest {
 
     @Test
     fun findOneVersion_shouldGracefullyFail() {
-        mockMvc.perform(get("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/42")
+        mockMvc.perform(get("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/versions/42")
                 .with(user("user"))
                 .with(csrf()))
                 .andExpect(status().isNotFound)
@@ -59,7 +59,7 @@ class VersionControllerIntegrationTest {
 
     @Test
     fun deleteVersion_shouldDeleteVersion() {
-        mockMvc.perform(delete("/api/v1/specifications/f67cb0a6-c31b-424b-bfbb-ab0e163955ca/v2")
+        mockMvc.perform(delete("/api/v1/specifications/f67cb0a6-c31b-424b-bfbb-ab0e163955ca/versions/v2")
             .with(user("user"))
             .with(csrf()))
             .andExpect(status().isOk)

--- a/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionControllerIntegrationTest.kt
+++ b/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionControllerIntegrationTest.kt
@@ -24,7 +24,7 @@ class VersionControllerIntegrationTest {
 
     @Test
     fun findOneVersion_shouldReturnVersion() {
-        mockMvc.perform(get("/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/versions/v1")
+        mockMvc.perform(get("/api/1.0/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/v1")
             .with(user("user"))
             .with(csrf()))
             .andExpect(jsonPath("$.version", equalTo("v1")))
@@ -50,7 +50,7 @@ class VersionControllerIntegrationTest {
 
     @Test
     fun deleteVersion_shouldDeleteVersion() {
-        mockMvc.perform(delete("/specifications/f67cb0a6-c31b-424b-bfbb-ab0e163955ca/versions/v2")
+        mockMvc.perform(delete("/api/1.0/specifications/f67cb0a6-c31b-424b-bfbb-ab0e163955ca/v2")
             .with(user("user"))
             .with(csrf()))
             .andExpect(status().isOk)

--- a/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionControllerIntegrationTest.kt
+++ b/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionControllerIntegrationTest.kt
@@ -24,7 +24,7 @@ class VersionControllerIntegrationTest {
 
     @Test
     fun findOneVersion_shouldReturnVersion() {
-        mockMvc.perform(get("/api/1.0/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/v1")
+        mockMvc.perform(get("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/v1")
             .with(user("user"))
             .with(csrf()))
             .andExpect(jsonPath("$.version", equalTo("v1")))
@@ -32,7 +32,7 @@ class VersionControllerIntegrationTest {
 
     @Test
     fun findOneVersion_shouldReturnJson() {
-        mockMvc.perform(get("/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/versions/v1")
+        mockMvc.perform(get("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/v1")
                 .header("Accept", "application/json")
                 .with(user("user"))
                 .with(csrf()))
@@ -41,7 +41,7 @@ class VersionControllerIntegrationTest {
 
     @Test
     fun findOneVersion_shouldReturnYaml() {
-        mockMvc.perform(get("/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/versions/v1")
+        mockMvc.perform(get("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/v1")
                 .header("Accept", "application/yml")
                 .with(user("user"))
                 .with(csrf()))
@@ -50,16 +50,16 @@ class VersionControllerIntegrationTest {
 
     @Test
     fun findOneVersion_shouldGracefullyFail() {
-        mockMvc.perform(get("/api/1.0/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/42")
+        mockMvc.perform(get("/api/v1/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/42")
                 .with(user("user"))
                 .with(csrf()))
-                .andExpect(status().`is`(404))
+                .andExpect(status().isNotFound)
     }
 
 
     @Test
     fun deleteVersion_shouldDeleteVersion() {
-        mockMvc.perform(delete("/api/1.0/specifications/f67cb0a6-c31b-424b-bfbb-ab0e163955ca/v2")
+        mockMvc.perform(delete("/api/v1/specifications/f67cb0a6-c31b-424b-bfbb-ab0e163955ca/v2")
             .with(user("user"))
             .with(csrf()))
             .andExpect(status().isOk)

--- a/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionControllerIntegrationTest.kt
+++ b/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionControllerIntegrationTest.kt
@@ -49,6 +49,15 @@ class VersionControllerIntegrationTest {
     }
 
     @Test
+    fun findOneVersion_shouldGracefullyFail() {
+        mockMvc.perform(get("/api/1.0/specifications/b6b06513-d259-4faf-b34b-a216b3daad6a/42")
+                .with(user("user"))
+                .with(csrf()))
+                .andExpect(status().`is`(404))
+    }
+
+
+    @Test
     fun deleteVersion_shouldDeleteVersion() {
         mockMvc.perform(delete("/api/1.0/specifications/f67cb0a6-c31b-424b-bfbb-ab0e163955ca/v2")
             .with(user("user"))

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/SecurityConfiguration.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/SecurityConfiguration.kt
@@ -25,7 +25,7 @@ class SecurityConfiguration : WebSecurityConfigurerAdapter() {
                 .and()
                 .csrf().disable()
                 .authorizeRequests()
-                .antMatchers("/sessions").permitAll()
+                .antMatchers("/api/1.0/sessions").permitAll()
 
                 // Angular route permissions
                 // Should be available to unauthenticated users
@@ -38,7 +38,7 @@ class SecurityConfiguration : WebSecurityConfigurerAdapter() {
                 .antMatchers("/index.html").permitAll()
                 .antMatchers("/*.js*").permitAll()
                 .antMatchers("/open-iconic.*").permitAll()
-                .anyRequest().authenticated()
+                .anyRequest().permitAll()
                 .and()
                 .addFilter(JwtAuthorizationFilter(authenticationManager(), jwtSecuritySecret))
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/SecurityConfiguration.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/SecurityConfiguration.kt
@@ -38,7 +38,7 @@ class SecurityConfiguration : WebSecurityConfigurerAdapter() {
                 .antMatchers("/index.html").permitAll()
                 .antMatchers("/*.js*").permitAll()
                 .antMatchers("/open-iconic.*").permitAll()
-                .anyRequest().permitAll()
+                .anyRequest().authenticated()
                 .and()
                 .addFilter(JwtAuthorizationFilter(authenticationManager(), jwtSecuritySecret))
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/SecurityConfiguration.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/SecurityConfiguration.kt
@@ -25,7 +25,7 @@ class SecurityConfiguration : WebSecurityConfigurerAdapter() {
                 .and()
                 .csrf().disable()
                 .authorizeRequests()
-                .antMatchers("/api/1.0/sessions").permitAll()
+                .antMatchers("/api/v1/sessions").permitAll()
 
                 // Angular route permissions
                 // Should be available to unauthenticated users

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/SecurityConfiguration.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/SecurityConfiguration.kt
@@ -21,22 +21,27 @@ class SecurityConfiguration : WebSecurityConfigurerAdapter() {
 
     override fun configure(httpSecurity: HttpSecurity) {
         httpSecurity
-            .cors()
-            .and()
-            .csrf().disable()
-            .authorizeRequests()
-            .antMatchers("/sessions").permitAll()
+                .cors()
+                .and()
+                .csrf().disable()
+                .authorizeRequests()
+                .antMatchers("/sessions").permitAll()
 
-            .antMatchers("/").permitAll()
-            .antMatchers("/3rdpartylicenses.txt").permitAll()
-            .antMatchers("/favicon.ico").permitAll()
-            .antMatchers("/index.html").permitAll()
-            .antMatchers("/*.js*").permitAll()
-            .antMatchers("/open-iconic.*").permitAll()
-            .anyRequest().authenticated()
-            .and()
-            .addFilter(JwtAuthorizationFilter(authenticationManager(), jwtSecuritySecret))
-            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                // Angular route permissions
+                // Should be available to unauthenticated users
+                .antMatchers("/").permitAll()
+                .antMatchers("/login").permitAll()
+
+                // Angular resources required by anyone, for the unauthenticated to login
+                .antMatchers("/3rdpartylicenses.txt").permitAll()
+                .antMatchers("/favicon.ico").permitAll()
+                .antMatchers("/index.html").permitAll()
+                .antMatchers("/*.js*").permitAll()
+                .antMatchers("/open-iconic.*").permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .addFilter(JwtAuthorizationFilter(authenticationManager(), jwtSecuritySecret))
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
     }
 
     @Throws(Exception::class)

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/WebConfiguration.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/WebConfiguration.kt
@@ -19,8 +19,6 @@ class WebConfiguration {
 
             override fun addViewControllers(registry: ViewControllerRegistry) {
                 // Redirect to Angular's router
-                // In case you either refresh the page, or want to send a static link to someone
-                // and don't want to get a 403 when running the mono build
                 registry.addViewController("/specifications/*/*").setViewName("forward:/index.html")
                 registry.addViewController("/add-specifications").setViewName("forward:/index.html")
                 registry.addViewController("/edit-specifications/**").setViewName("forward:/index.html")

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/WebConfiguration.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/WebConfiguration.kt
@@ -3,6 +3,7 @@ package com.tngtech.apicenter.backend.config
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
@@ -14,6 +15,18 @@ class WebConfiguration {
             override fun addCorsMappings(corsRegistry: CorsRegistry) {
                 corsRegistry.addMapping("/**").allowedOrigins("*").allowedMethods("*")
                     .allowedHeaders("*")
+            }
+
+            override fun addViewControllers(registry: ViewControllerRegistry) {
+                // Redirect to Angular's router
+                // In case you either refresh the page, or want to send a static link to someone
+                // and don't want to get a 403 when running the mono build
+                registry.addViewController("/specifications/*/*").setViewName("forward:/index.html")
+                registry.addViewController("/add-specifications").setViewName("forward:/index.html")
+                registry.addViewController("/edit-specifications/**").setViewName("forward:/index.html")
+                registry.addViewController("/search").setViewName("forward:/index.html")
+                registry.addViewController("/search/**").setViewName("forward:/index.html")
+                registry.addViewController("/login").setViewName("forward:/index.html")
             }
         }
     }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/SpecificationDatabaseService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/SpecificationDatabaseService.kt
@@ -9,7 +9,6 @@ import org.hibernate.search.jpa.Search
 import org.springframework.stereotype.Service
 import java.lang.Exception
 import java.lang.IllegalArgumentException
-import java.sql.SQLException
 import java.util.UUID
 import javax.persistence.EntityManager
 import javax.transaction.Transactional
@@ -39,7 +38,7 @@ class SpecificationDatabaseService constructor(
     override fun findAll(): List<Specification> = specificationRepository.findAll().map { spec -> specificationEntityMapper.toDomain(spec) }
 
     override fun findOne(id: UUID): Specification? =
-        specificationRepository.findById(id).map { spec -> specificationEntityMapper.toDomain(spec) }.get()
+        specificationRepository.findById(id).orElse(null)?.let { spec -> specificationEntityMapper.toDomain(spec) }
 
     override fun delete(id: UUID) = specificationRepository.deleteById(id)
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/VersionDatabaseService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/VersionDatabaseService.kt
@@ -2,7 +2,6 @@ package com.tngtech.apicenter.backend.connector.database.service
 
 import com.tngtech.apicenter.backend.connector.database.entity.VersionId
 import com.tngtech.apicenter.backend.connector.database.mapper.VersionEntityMapper
-import com.tngtech.apicenter.backend.connector.database.repository.SpecificationRepository
 import com.tngtech.apicenter.backend.connector.database.repository.VersionRepository
 import com.tngtech.apicenter.backend.domain.entity.Version
 import com.tngtech.apicenter.backend.domain.service.VersionPersistenceService
@@ -12,12 +11,11 @@ import java.util.UUID
 @Service
 class VersionDatabaseService constructor(
     private val versionRepository: VersionRepository,
-    private val specificationRepository: SpecificationRepository,
     private val versionEntityMapper: VersionEntityMapper
 ) : VersionPersistenceService {
 
-    override fun findOne(specificationId: UUID, versionTitle: String): Version {
-        return versionRepository.findById(VersionId(specificationId, versionTitle)).map { version -> versionEntityMapper.toDomain(version) }.get()
+    override fun findOne(specificationId: UUID, versionTitle: String): Version? {
+        return versionRepository.findById(VersionId(specificationId, versionTitle)).orElse(null)?.let { version -> versionEntityMapper.toDomain(version) }
     }
 
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SessionController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SessionController.kt
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/api/1.0/sessions")
+@RequestMapping("/api/v1/sessions")
 class SessionController @Autowired constructor(private val sessionHandler: SessionHandler) {
 
     @Value("\${jwt.secret}")

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SessionController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SessionController.kt
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("/sessions")
+@RequestMapping("/api/1.0/sessions")
 class SessionController @Autowired constructor(private val sessionHandler: SessionHandler) {
 
     @Value("\${jwt.secret}")

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SharedRestControllerExceptions.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SharedRestControllerExceptions.kt
@@ -1,0 +1,7 @@
+package com.tngtech.apicenter.backend.connector.rest.controller
+
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.http.HttpStatus
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "Specification not found")
+class HttpNotFoundException : RuntimeException()

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
@@ -16,10 +16,10 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
+import java.util.*
 
 @RestController
-@RequestMapping("/specifications")
+@RequestMapping("/api/1.0/specifications")
 class SpecificationController @Autowired constructor(
     private val specificationHandler: SpecificationHandler,
     private val synchronizationService: SynchronizationService,
@@ -57,8 +57,15 @@ class SpecificationController @Autowired constructor(
         specificationHandler.findAll().map { spec -> specificationDtoMapper.fromDomain(spec) }
 
     @GetMapping("/{specificationId}")
-    fun findSpecification(@PathVariable specificationId: UUID): SpecificationDto =
-        specificationDtoMapper.fromDomain(specificationHandler.findOne(specificationId)!!)
+    @Throws(HttpNotFoundException::class)
+    fun findSpecification(@PathVariable specificationId: UUID): SpecificationDto {
+        val specification = specificationHandler.findOne(specificationId)
+
+        if (specification != null) {
+            return specificationDtoMapper.fromDomain(specification)
+        }
+        throw HttpNotFoundException()
+    }
 
     @DeleteMapping("/{specificationId}")
     fun deleteSpecification(@PathVariable specificationId: UUID) {

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 import java.util.*
 
 @RestController
-@RequestMapping("/api/1.0/specifications")
+@RequestMapping("/api/v1/specifications")
 class SpecificationController @Autowired constructor(
     private val specificationHandler: SpecificationHandler,
     private val synchronizationService: SynchronizationService,
@@ -60,11 +60,7 @@ class SpecificationController @Autowired constructor(
     @Throws(HttpNotFoundException::class)
     fun findSpecification(@PathVariable specificationId: UUID): SpecificationDto {
         val specification = specificationHandler.findOne(specificationId)
-
-        if (specification != null) {
-            return specificationDtoMapper.fromDomain(specification)
-        }
-        throw HttpNotFoundException()
+        return specification?.let { specificationDtoMapper.fromDomain(it) } ?: throw HttpNotFoundException()
     }
 
     @DeleteMapping("/{specificationId}")

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionController.kt
@@ -19,7 +19,7 @@ private const val MEDIA_TYPE_YAML = "application/yml"
 class VersionController constructor(private val versionHandler: VersionHandler, private val versionDtoMapper: VersionDtoMapper) {
 
     @Throws(HttpNotFoundException::class)
-    @RequestMapping("/api/v1/specifications/{specificationId}/{version}",
+    @RequestMapping("/api/v1/specifications/{specificationId}/versions/{version}",
             produces = [MediaType.APPLICATION_JSON_VALUE,
                         MEDIA_TYPE_YAML],
             headers =  ["Accept=" + MediaType.APPLICATION_JSON_VALUE,
@@ -44,7 +44,7 @@ class VersionController constructor(private val versionHandler: VersionHandler, 
         }
     }
 
-    @DeleteMapping("/api/v1/specifications/{specificationId}/{version}")
+    @DeleteMapping("/api/v1/specifications/{specificationId}/versions/{version}")
     fun deleteVersion(@PathVariable specificationId: UUID, @PathVariable version: String) {
         versionHandler.delete(specificationId, version)
     }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionController.kt
@@ -18,9 +18,8 @@ private const val MEDIA_TYPE_YAML = "application/yml"
 @RestController
 class VersionController constructor(private val versionHandler: VersionHandler, private val versionDtoMapper: VersionDtoMapper) {
 
-    @GetMapping("/api/1.0/specifications/{specificationId}/{version}")
     @Throws(HttpNotFoundException::class)
-    @RequestMapping("/specifications/{specificationId}/versions/{version}",
+    @RequestMapping("/api/v1/specifications/{specificationId}/{version}",
             produces = [MediaType.APPLICATION_JSON_VALUE,
                         MEDIA_TYPE_YAML],
             headers =  ["Accept=" + MediaType.APPLICATION_JSON_VALUE,
@@ -45,7 +44,7 @@ class VersionController constructor(private val versionHandler: VersionHandler, 
         }
     }
 
-    @DeleteMapping("/api/1.0/specifications/{specificationId}/{version}")
+    @DeleteMapping("/api/v1/specifications/{specificationId}/{version}")
     fun deleteVersion(@PathVariable specificationId: UUID, @PathVariable version: String) {
         versionHandler.delete(specificationId, version)
     }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/handler/SpecificationHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/handler/SpecificationHandler.kt
@@ -15,7 +15,7 @@ class SpecificationHandler @Autowired constructor(private val specificationPersi
 
     fun findAll() = specificationPersistenceService.findAll()
 
-    fun findOne(id: UUID) = specificationPersistenceService.findOne(id)
+    fun findOne(id: UUID): Specification? = specificationPersistenceService.findOne(id)
 
     fun delete(id: UUID) = specificationPersistenceService.delete(id)
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/handler/VersionHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/handler/VersionHandler.kt
@@ -1,14 +1,14 @@
 package com.tngtech.apicenter.backend.domain.handler
 
-import com.tngtech.apicenter.backend.domain.service.SpecificationPersistenceService
 import com.tngtech.apicenter.backend.domain.service.VersionPersistenceService
+import com.tngtech.apicenter.backend.domain.entity.Version
 import org.springframework.stereotype.Component
 import java.util.UUID
 
 @Component
 class VersionHandler constructor(private val versionPersistenceService: VersionPersistenceService) {
 
-    fun findOne(specificationId: UUID, version: String) = versionPersistenceService.findOne(specificationId, version)
+    fun findOne(specificationId: UUID, version: String): Version? = versionPersistenceService.findOne(specificationId, version)
 
     fun delete(specificationId: UUID, version: String) = versionPersistenceService.delete(specificationId, version)
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/service/VersionPersistenceService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/service/VersionPersistenceService.kt
@@ -4,6 +4,6 @@ import com.tngtech.apicenter.backend.domain.entity.Version
 import java.util.UUID
 
 interface VersionPersistenceService {
-    fun findOne(specificationId: UUID, versionTitle: String): Version
+    fun findOne(specificationId: UUID, versionTitle: String): Version?
     fun delete(specificationId: UUID, versionTitle: String)
 }

--- a/backend/src/main/resources/api-definition.json
+++ b/backend/src/main/resources/api-definition.json
@@ -17,7 +17,7 @@
     }
   ],
   "paths": {
-    "/specifications": {
+    "/api/1.0/specifications": {
       "get": {
         "tags": [
           "specification-controller"
@@ -118,7 +118,7 @@
         "deprecated": false
       }
     },
-    "/specifications/search/{searchString}": {
+    "/api/1.0/specifications/search/{searchString}": {
       "get": {
         "tags": [
           "specification-controller"
@@ -169,7 +169,7 @@
         "deprecated": false
       }
     },
-    "/specifications/{specificationId}": {
+    "/api/1.0/specifications/{specificationId}": {
       "get": {
         "tags": [
           "specification-controller"
@@ -326,7 +326,7 @@
         "deprecated": false
       }
     },
-    "/specifications/{specificationId}/synchronize": {
+    "/api/1.0/specifications/{specificationId}/synchronize": {
       "post": {
         "tags": [
           "specification-controller"
@@ -374,7 +374,7 @@
         "deprecated": false
       }
     },
-    "/specifications/{specificationId}/versions/{version}": {
+    "/api/1.0/specifications/{specificationId}/{version}": {
       "get": {
         "tags": [
           "version-controller"
@@ -470,7 +470,7 @@
         }
       }
     },
-    "/sessions": {
+    "/api/1.0/sessions": {
       "post": {
         "tags": [
           "session-controller"

--- a/backend/src/main/resources/api-definition.json
+++ b/backend/src/main/resources/api-definition.json
@@ -399,6 +399,14 @@
             "required": true,
             "type": "string",
             "format": "uuid"
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "description": "JWT to authenticate the user, preceded with the string 'Bearer '",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/backend/src/main/resources/api-definition.json
+++ b/backend/src/main/resources/api-definition.json
@@ -374,7 +374,7 @@
         "deprecated": false
       }
     },
-    "/api/v1/specifications/{specificationId}/{version}": {
+    "/api/v1/specifications/{specificationId}/versions/{version}": {
       "get": {
         "tags": [
           "version-controller"

--- a/backend/src/main/resources/api-definition.json
+++ b/backend/src/main/resources/api-definition.json
@@ -17,7 +17,7 @@
     }
   ],
   "paths": {
-    "/api/1.0/specifications": {
+    "/api/v1/specifications": {
       "get": {
         "tags": [
           "specification-controller"
@@ -118,7 +118,7 @@
         "deprecated": false
       }
     },
-    "/api/1.0/specifications/search/{searchString}": {
+    "/api/v1/specifications/search/{searchString}": {
       "get": {
         "tags": [
           "specification-controller"
@@ -169,7 +169,7 @@
         "deprecated": false
       }
     },
-    "/api/1.0/specifications/{specificationId}": {
+    "/api/v1/specifications/{specificationId}": {
       "get": {
         "tags": [
           "specification-controller"
@@ -326,7 +326,7 @@
         "deprecated": false
       }
     },
-    "/api/1.0/specifications/{specificationId}/synchronize": {
+    "/api/v1/specifications/{specificationId}/synchronize": {
       "post": {
         "tags": [
           "specification-controller"
@@ -374,7 +374,7 @@
         "deprecated": false
       }
     },
-    "/api/1.0/specifications/{specificationId}/{version}": {
+    "/api/v1/specifications/{specificationId}/{version}": {
       "get": {
         "tags": [
           "version-controller"
@@ -470,7 +470,7 @@
         }
       }
     },
-    "/api/1.0/sessions": {
+    "/api/v1/sessions": {
       "post": {
         "tags": [
           "session-controller"

--- a/frontend/src/app/specification-overview/specification-overview.component.ts
+++ b/frontend/src/app/specification-overview/specification-overview.component.ts
@@ -53,19 +53,19 @@ export class SpecificationOverviewComponent implements OnInit {
 
   public downloadVersion(filetype: String, spec: Specification, version: Version) {
     if (filetype === 'json') {
-      return this.downloadJSONVersion(spec, version);
+      return this.downloadJsonVersion(spec, version);
     } else if (filetype === 'yaml') {
-      return this.downloadYAMLVersion(spec, version);
+      return this.downloadYamlVersion(spec, version);
     }
   }
 
-  public downloadJSONVersion(specification: Specification, version: Version) {
+  public downloadJsonVersion(specification: Specification, version: Version) {
     const fileName = this.createDownloadFileName(specification, version);
     const content = JSON.stringify(JSON.parse(version.content), null, 2);
     this.doDownload(content, fileName + '.json', 'application/json');
   }
 
-  public downloadYAMLVersion(specification: Specification, version: Version) {
+  public downloadYamlVersion(specification: Specification, version: Version) {
     const fileName = this.createDownloadFileName(specification, version);
     this.versionService.getYamlVersion(specification.id, version.version)
       .subscribe(event => {

--- a/frontend/src/app/specification-overview/specification-overview.component.ts
+++ b/frontend/src/app/specification-overview/specification-overview.component.ts
@@ -67,7 +67,7 @@ export class SpecificationOverviewComponent implements OnInit {
 
   public downloadYAMLVersion(specification: Specification, version: Version) {
     const fileName = this.createDownloadFileName(specification, version);
-    this.versionService.getYAMLVersion(specification.id, version.version)
+    this.versionService.getYamlVersion(specification.id, version.version)
       .subscribe(event => {
         this.doDownload(event.content, fileName + '.yml', 'application/yaml');
       });

--- a/frontend/src/app/specification-version/specification-version.component.html
+++ b/frontend/src/app/specification-version/specification-version.component.html
@@ -1,3 +1,8 @@
 <div class="container">
+  <div class="row top-buffer">
+    <div class="alert alert-danger" role="alert" *ngIf="error">
+      {{ error }}
+    </div>
+  </div>
   <div id="display-swagger-ui"></div>
 </div>

--- a/frontend/src/app/specification-version/specification-version.component.ts
+++ b/frontend/src/app/specification-version/specification-version.component.ts
@@ -18,7 +18,7 @@ export class SpecificationVersionComponent implements OnInit {
 
   ngOnInit() {
     this.specification = this.route.params.subscribe(params => {
-      this.http.get(environment.apiUrl + '/specifications/' + params['specificationId'] + '/' + params['version'])
+      this.http.get(environment.apiUrl + '/specifications/' + params['specificationId'] + '/versions/' + params['version'])
         .subscribe((data: any[]) => {
           this.specification = data;
           this.displaySwaggerUi();

--- a/frontend/src/app/specification-version/specification-version.component.ts
+++ b/frontend/src/app/specification-version/specification-version.component.ts
@@ -17,7 +17,7 @@ export class SpecificationVersionComponent implements OnInit {
 
   ngOnInit() {
     this.specification = this.route.params.subscribe(params => {
-      this.http.get(environment.apiUrl + '/specifications/' + params['specificationId'] + '/versions/' + params['version'])
+      this.http.get(environment.apiUrl + '/specifications/' + params['specificationId'] + '/' + params['version'])
         .subscribe((data: any[]) => {
           this.specification = data;
           this.displaySwaggerUi();

--- a/frontend/src/app/specification-version/specification-version.component.ts
+++ b/frontend/src/app/specification-version/specification-version.component.ts
@@ -10,6 +10,7 @@ import * as SwaggerUI from 'swagger-ui';
   styleUrls: ['./specification-version.component.css']
 })
 export class SpecificationVersionComponent implements OnInit {
+  error: String;
   specification;
 
   constructor(private route: ActivatedRoute, private http: HttpClient) {
@@ -21,6 +22,11 @@ export class SpecificationVersionComponent implements OnInit {
         .subscribe((data: any[]) => {
           this.specification = data;
           this.displaySwaggerUi();
+        },
+          err => {
+            if (err.status === 404) {
+              this.error = 'Version not found';
+            }
         });
     });
   }

--- a/frontend/src/app/specification.service.spec.ts
+++ b/frontend/src/app/specification.service.spec.ts
@@ -15,7 +15,7 @@ describe('SpecificationService', () => {
   const firstVersions = [new Version('1.0', 'Content')];
   const secondVersions = [new Version('v1', 'Content'),
     new Version('v2', 'Content')];
-  const specifications = [new Specification('d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6', 'API 1', 'Decription', firstVersions, null),
+  const specifications = [new Specification('d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6', 'API 1', 'Description', firstVersions, null),
     new Specification('14dcb74e-f275-42fa-8f95-b26b3a4702c8', 'API 2', 'Description', secondVersions, 'http://address.com/test.json')];
   const swagger_content = '{\'swagger\': \'2.0\', \'info\': {\'version\': \'1.0.0\',\'title\': \'Swagger Petstore\'}}';
   const specificationFile = new SpecificationFile(swagger_content, null);
@@ -25,7 +25,7 @@ describe('SpecificationService', () => {
   });
 
   it('should return specification', () => {
-    when(mockedHttpClient.get('http://localhost:8080/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6'))
+    when(mockedHttpClient.get('http://localhost:8080/api/1.0/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6'))
       .thenReturn(from([specifications[0]]));
 
     specificationService.getSpecification('d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6').subscribe((data: Specification) => {
@@ -34,7 +34,7 @@ describe('SpecificationService', () => {
   });
 
   it('should create specification', () => {
-    when(mockedHttpClient.post('http://localhost:8080/specifications', specificationFile))
+    when(mockedHttpClient.post('http://localhost:8080/api/1.0/specifications', specificationFile))
       .thenReturn(from([specifications[0]]));
 
     specificationService.createSpecification(specificationFile).subscribe((data: Specification) => {
@@ -43,7 +43,7 @@ describe('SpecificationService', () => {
   });
 
   it('should update specification', () => {
-    when(mockedHttpClient.put('http://localhost:8080/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6', specificationFile))
+    when(mockedHttpClient.put('http://localhost:8080/api/1.0/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6', specificationFile))
       .thenReturn(from([specifications[0]]));
 
     specificationService.updateSpecification(specificationFile, 'd2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6').subscribe((data: Specification) => {
@@ -52,20 +52,22 @@ describe('SpecificationService', () => {
   });
 
   it('should deleteSpecification specification', () => {
-    when(mockedHttpClient.delete('http://localhost:8080/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6'))
+    when(mockedHttpClient.delete('http://localhost:8080/api/1.0/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6'))
       .thenReturn(from([]));
 
     specificationService.deleteSpecification('d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6').subscribe(() => {
-      verify(mockedHttpClient.delete('http://localhost:8080/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6')).called();
+      verify(mockedHttpClient.delete('http://localhost:8080/api/1.0/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6')).called();
     });
   });
 
   it('should synchronize specification', () => {
-    when(mockedHttpClient.post('http://localhost:8080/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6/synchronize', ''))
+    when(mockedHttpClient.post('http://localhost:8080/api/1.0/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6/synchronize', ''))
       .thenReturn(from([]));
 
     specificationService.synchronizeSpecification('d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6').subscribe(() => {
-      verify(mockedHttpClient.post('http://localhost:8080/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6/synchronize', '')).called();
+      verify(mockedHttpClient
+        .post('http://localhost:8080/api/1.0/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6/synchronize', ''))
+        .called();
     });
   });
 });

--- a/frontend/src/app/specification.service.spec.ts
+++ b/frontend/src/app/specification.service.spec.ts
@@ -25,7 +25,7 @@ describe('SpecificationService', () => {
   });
 
   it('should return specification', () => {
-    when(mockedHttpClient.get('http://localhost:8080/api/1.0/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6'))
+    when(mockedHttpClient.get('http://localhost:8080/api/v1/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6'))
       .thenReturn(from([specifications[0]]));
 
     specificationService.getSpecification('d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6').subscribe((data: Specification) => {
@@ -34,7 +34,7 @@ describe('SpecificationService', () => {
   });
 
   it('should create specification', () => {
-    when(mockedHttpClient.post('http://localhost:8080/api/1.0/specifications', specificationFile))
+    when(mockedHttpClient.post('http://localhost:8080/api/v1/specifications', specificationFile))
       .thenReturn(from([specifications[0]]));
 
     specificationService.createSpecification(specificationFile).subscribe((data: Specification) => {
@@ -43,7 +43,7 @@ describe('SpecificationService', () => {
   });
 
   it('should update specification', () => {
-    when(mockedHttpClient.put('http://localhost:8080/api/1.0/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6', specificationFile))
+    when(mockedHttpClient.put('http://localhost:8080/api/v1/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6', specificationFile))
       .thenReturn(from([specifications[0]]));
 
     specificationService.updateSpecification(specificationFile, 'd2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6').subscribe((data: Specification) => {
@@ -52,21 +52,21 @@ describe('SpecificationService', () => {
   });
 
   it('should deleteSpecification specification', () => {
-    when(mockedHttpClient.delete('http://localhost:8080/api/1.0/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6'))
+    when(mockedHttpClient.delete('http://localhost:8080/api/v1/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6'))
       .thenReturn(from([]));
 
     specificationService.deleteSpecification('d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6').subscribe(() => {
-      verify(mockedHttpClient.delete('http://localhost:8080/api/1.0/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6')).called();
+      verify(mockedHttpClient.delete('http://localhost:8080/api/v1/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6')).called();
     });
   });
 
   it('should synchronize specification', () => {
-    when(mockedHttpClient.post('http://localhost:8080/api/1.0/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6/synchronize', ''))
+    when(mockedHttpClient.post('http://localhost:8080/api/v1/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6/synchronize', ''))
       .thenReturn(from([]));
 
     specificationService.synchronizeSpecification('d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6').subscribe(() => {
       verify(mockedHttpClient
-        .post('http://localhost:8080/api/1.0/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6/synchronize', ''))
+        .post('http://localhost:8080/api/v1/specifications/d2317ad4-b6b4-4bc5-a3cc-7eed72eeedb6/synchronize', ''))
         .called();
     });
   });

--- a/frontend/src/app/version.service.ts
+++ b/frontend/src/app/version.service.ts
@@ -13,17 +13,17 @@ export class VersionService {
 
   public getYamlVersion(specificationId: string, version: string) {
     const headers = new HttpHeaders({'Accept': 'application/yml'});
-    return this.http.get<Version>(this.versionUrl + '/' + specificationId + '/' + version, {headers})
+    return this.http.get<Version>(this.versionUrl + '/' + specificationId + '/versions/' + version, {headers})
       .catch((error: any) => throwError(error || 'Server error'));
   }
 
   public getJsonVersion(specificationId: string, version: string) {
-    return this.http.get<Version>(this.versionUrl + '/' + specificationId + '/' + version)
+    return this.http.get<Version>(this.versionUrl + '/' + specificationId + '/versions/' + version)
       .catch((error: any) => throwError(error || 'Server error'));
   }
 
   public deleteVersion(specificationId: string, version: string): Observable<Version> {
-    return this.http.delete<Version>(this.versionUrl + '/' + specificationId + '/' + version)
+    return this.http.delete<Version>(this.versionUrl + '/' + specificationId + '/versions/' + version)
       .catch((error: any) => throwError(error || 'Server error'));
   }
 }

--- a/frontend/src/app/version.service.ts
+++ b/frontend/src/app/version.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import {environment} from '../environments/environment';
 import {HttpClient, HttpHeaders} from '@angular/common/http';
-import {Specification} from './models/specification';
 import {Observable, throwError} from 'rxjs';
 import {Version} from './models/version';
 
@@ -12,14 +11,19 @@ export class VersionService {
 
   constructor(private http: HttpClient) { }
 
-  public getYAMLVersion(specificationId: string, version: string) {
+  public getYamlVersion(specificationId: string, version: string) {
     const headers = new HttpHeaders({'Accept': 'application/yml'});
     return this.http.get<Version>(this.versionUrl + '/' + specificationId + '/versions/' + version, {headers})
       .catch((error: any) => throwError(error || 'Server error'));
   }
 
+  public getJsonVersion(specificationId: string, version: string) {
+    return this.http.get<Version>(this.versionUrl + '/' + specificationId + '/' + version)
+      .catch((error: any) => throwError(error || 'Server error'));
+  }
+
   public deleteVersion(specificationId: string, version: string): Observable<Version> {
-    return this.http.delete<Version>(this.versionUrl + '/' + specificationId + '/versions/' + version)
+    return this.http.delete<Version>(this.versionUrl + '/' + specificationId + '/' + version)
       .catch((error: any) => throwError(error || 'Server error'));
   }
 }

--- a/frontend/src/app/version.service.ts
+++ b/frontend/src/app/version.service.ts
@@ -13,7 +13,7 @@ export class VersionService {
 
   public getYamlVersion(specificationId: string, version: string) {
     const headers = new HttpHeaders({'Accept': 'application/yml'});
-    return this.http.get<Version>(this.versionUrl + '/' + specificationId + '/versions/' + version, {headers})
+    return this.http.get<Version>(this.versionUrl + '/' + specificationId + '/' + version, {headers})
       .catch((error: any) => throwError(error || 'Server error'));
   }
 

--- a/frontend/src/environments/environment.localhost.ts
+++ b/frontend/src/environments/environment.localhost.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:8080'
+  apiUrl: 'http://localhost:8080/api/1.0'
 };

--- a/frontend/src/environments/environment.localhost.ts
+++ b/frontend/src/environments/environment.localhost.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:8080/api/1.0'
+  apiUrl: 'http://localhost:8080/api/v1'
 };

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiUrl: window.location.origin
+  apiUrl: window.location.origin + '/api/1.0'
 };

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiUrl: window.location.origin + '/api/1.0'
+  apiUrl: window.location.origin + '/api/v1'
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiUrl: window.location.origin + '/api/1.0'
+  apiUrl: window.location.origin + '/api/v1'
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
-  apiUrl: window.location.origin
+  apiUrl: window.location.origin + '/api/1.0'
 };


### PR DESCRIPTION
Two related changes here to do with the API

## API redefinition
Firstly, modifies Spring config to route all HTTP requests to Angular. Before, every route within Angular's SPA had to be accessed from the root; if the user refreshed the page or sent a static link to someone, Spring would return 404.

Secondly, because both API path requests and Angular routes are now in the same scope / namespace, adds a prefix to all API calls, to distinguish the two services. Updates integration tests. (Also removes '/versions/' from API calls, to make the API vs Angular paths consistent.)

## Add handling for unfound versions / specifications

Before, the findOne methods assumed every request for a version / specification would succeed. When the user gave a non-existent specification ID, the server threw an exception, and 500 was returned to the client.

Now curl requests for non-existent IDs return 404 (fix #46), and in the web frontend, an error banner appears instead of the whole page being blank (fix #47)