### PR TITLE
Add more specific HTTP codes in responses

### DIFF
--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/SpecificationDatabaseService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/SpecificationDatabaseService.kt
@@ -6,7 +6,9 @@ import com.tngtech.apicenter.backend.connector.database.repository.Specification
 import com.tngtech.apicenter.backend.domain.entity.Specification
 import com.tngtech.apicenter.backend.domain.service.SpecificationPersistenceService
 import org.hibernate.search.jpa.Search
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
 import java.lang.Exception
 import java.lang.IllegalArgumentException
 import java.util.UUID
@@ -67,7 +69,7 @@ class SpecificationDatabaseService constructor(
         try {
             specificationRepository.save(specificationEntity)
         } catch (sqlException: Exception) {
-            throw IllegalArgumentException("This version already exists for specification ${specificationEntity.title}.", sqlException)
+            throw ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "This version already exists for specification ${specificationEntity.title}.", sqlException)
         }
     }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SharedRestControllerExceptions.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SharedRestControllerExceptions.kt
@@ -1,7 +1,0 @@
-package com.tngtech.apicenter.backend.connector.rest.controller
-
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.http.HttpStatus
-
-@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "Specification not found")
-class HttpNotFoundException : RuntimeException()

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
 import java.util.*
 
 @RestController
@@ -57,10 +58,10 @@ class SpecificationController @Autowired constructor(
         specificationHandler.findAll().map { spec -> specificationDtoMapper.fromDomain(spec) }
 
     @GetMapping("/{specificationId}")
-    @Throws(HttpNotFoundException::class)
     fun findSpecification(@PathVariable specificationId: UUID): SpecificationDto {
         val specification = specificationHandler.findOne(specificationId)
-        return specification?.let { specificationDtoMapper.fromDomain(it) } ?: throw HttpNotFoundException()
+        return specification?.let { specificationDtoMapper.fromDomain(it) } ?:
+            throw ResponseStatusException(HttpStatus.NOT_FOUND, "Specification not found")
     }
 
     @DeleteMapping("/{specificationId}")

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionController.kt
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.http.MediaType
 import java.util.UUID
 import mu.KotlinLogging
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
 
 private val logger = KotlinLogging.logger {}
 private const val MEDIA_TYPE_YAML = "application/yml"
@@ -18,7 +20,6 @@ private const val MEDIA_TYPE_YAML = "application/yml"
 @RestController
 class VersionController constructor(private val versionHandler: VersionHandler, private val versionDtoMapper: VersionDtoMapper) {
 
-    @Throws(HttpNotFoundException::class)
     @RequestMapping("/api/v1/specifications/{specificationId}/versions/{version}",
             produces = [MediaType.APPLICATION_JSON_VALUE,
                         MEDIA_TYPE_YAML],
@@ -32,7 +33,7 @@ class VersionController constructor(private val versionHandler: VersionHandler, 
         // i.e. The integration test and unit test require the default specified in two different ways
         val foundVersion = versionHandler.findOne(specificationId, version)
         if (foundVersion == null) {
-            throw HttpNotFoundException()
+            throw ResponseStatusException(HttpStatus.NOT_FOUND, "Version not found")
         } else if (accept == MEDIA_TYPE_YAML) {
             logger.info("Specification $specificationId version $version requested as YAML")
             val jsonNodeTree = ObjectMapper().readTree(foundVersion.content)

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.jayway.jsonpath.JsonPath
 import com.jayway.jsonpath.PathNotFoundException
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
 import java.io.IOException
 
 @Service
@@ -49,7 +51,7 @@ class SpecificationDataService @Autowired constructor(
         try {
             return JsonPath.read<String>(json, "$.info.title")
         } catch (exception: PathNotFoundException) {
-            throw IllegalArgumentException("No title given in content.", exception)
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Specification needs a title", exception)
         }
     }
 
@@ -57,7 +59,7 @@ class SpecificationDataService @Autowired constructor(
         try {
             return JsonPath.read<String>(json, "$.info.version")
         } catch (exception: PathNotFoundException) {
-            throw IllegalArgumentException("No version given in content.", exception)
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Specification needs a version", exception)
         }
     }
 

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataServiceTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataServiceTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockitokotlin2.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
+import org.springframework.web.server.ResponseStatusException
 import java.io.IOException
 
 class SpecificationDataServiceTest {
@@ -53,15 +54,15 @@ class SpecificationDataServiceTest {
     @Test
     fun readTitle_shouldFailWhenNoTitleIsGiven() {
         assertThatThrownBy { specificationDataService.readTitle(SWAGGER_SPECIFICATION_WITHOUT_TITLE) }.isInstanceOf(
-            IllegalArgumentException::class.java
-        ).hasMessage("No title given in content.")
+            ResponseStatusException::class.java
+        ).hasMessageContaining("Specification needs a title")
     }
 
     @Test
     fun readVersion_shouldFailWhenNoVersionIsGiven() {
         assertThatThrownBy { specificationDataService.readVersion(SWAGGER_SPECIFICATION_WITHOUT_VERSION) }.isInstanceOf(
-            IllegalArgumentException::class.java
-        ).hasMessage("No version given in content.")
+            ResponseStatusException::class.java
+        ).hasMessageContaining("Specification needs a version")
     }
 
     @Test


### PR DESCRIPTION
What were bad client requests (eg. no title given in an OpenAPI specification) were all eliciting 500 code responses from the server. This also printed long stack traces in the kotlin logger.

This uses Spring's `ReponseStatusException` to return 4xx client error codes, with the added advantage of not printing stack traces.

The error messages are all still returned and displayed to the client correctly in the frontend.