### PR TITLE
Add some error handling to search

### DIFF
--- a/frontend/src/app/specification-search-detail/specification-search-detail.component.html
+++ b/frontend/src/app/specification-search-detail/specification-search-detail.component.html
@@ -10,6 +10,9 @@
         <div><p class="lead"><a [routerLink]="['/specifications', specification.id, specification.versions[0].version]" routerLinkActive="active">{{ specification.title }}</a></p></div>
         <div><p class="small"><markdown>{{ specification.description != null && specification.description.length > 100 ? (specification.description | slice:0:100) + ' ...' : specification.description }}</markdown></p></div>
       </div>
+      <div class="row top-buffer alert alert-danger" *ngIf="specifications.length == 0">
+        No specifications found
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
If you make an empty text query, Lucene (the string searching engine) gives an uncaught exception, and a long stack trace in the kotlin logger. [Certain English words](https://stackoverflow.com/questions/13765698/getting-error-on-a-specific-query) are so common that they are filtered out of text search queries, so, more realistically: if the user's entire query was composed of them, this exception is also thrown.

Also, this now displays a message if nothing is found (either because the query was empty, or because no specification content matched the query) instead of the page just being blank. A user might incorrectly think they are awaiting results.