### PR TITLE
Add HTTP response codes with @ControllerAdvice

### DIFF
--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
@@ -6,12 +6,25 @@ import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import java.time.Instant
 import java.time.format.DateTimeFormatter
+import mu.KotlinLogging
+import java.util.*
+
+private val logger = KotlinLogging.logger {  }
+class SpecificationNotFoundException(val specificationId: UUID, val version: String? = "") : RuntimeException()
+class SpecificationParseException(val msg: String) : RuntimeException()
+class VersionAlreadyExistsException(val specificationTitle: String) : RuntimeException()
+
+data class ErrorMessage(
+        val message: String,
+        val timestamp: String = DateTimeFormatter.ISO_INSTANT.format(Instant.now())
+)
 
 @ControllerAdvice
-class RestResponseExceptionHandler() {
+class RestResponseExceptionHandler {
 
     @ExceptionHandler(SpecificationNotFoundException::class)
-    fun handleNotFound(): ResponseEntity<ErrorMessage> {
+    fun handleNotFound(exc: SpecificationNotFoundException): ResponseEntity<ErrorMessage> {
+        logger.info("Specification ${exc.specificationId} ${exc.version} not found")
         return ResponseEntity(
                 ErrorMessage("Specification not found"),
                 null,
@@ -19,8 +32,8 @@ class RestResponseExceptionHandler() {
         )
     }
 
-    @ExceptionHandler(SpecificationParseFailureException::class)
-    fun handleBadRequest(exc: SpecificationParseFailureException): ResponseEntity<ErrorMessage> {
+    @ExceptionHandler(SpecificationParseException::class)
+    fun handleBadRequest(exc: SpecificationParseException): ResponseEntity<ErrorMessage> {
         return ResponseEntity(
                 ErrorMessage(exc.msg),
                 null,
@@ -33,16 +46,8 @@ class RestResponseExceptionHandler() {
         return ResponseEntity(
                 ErrorMessage("A specification with the same version already exists for ${exc.specificationTitle}"),
                 null,
-                HttpStatus.UNPROCESSABLE_ENTITY
+                HttpStatus.CONFLICT
         )
     }
 }
 
-class SpecificationNotFoundException : RuntimeException()
-class SpecificationParseFailureException(val msg: String) : RuntimeException()
-class VersionAlreadyExistsException(val specificationTitle: String) : RuntimeException()
-
-data class ErrorMessage(
-        val message: String,
-        val timestamp: String = DateTimeFormatter.ISO_INSTANT.format(Instant.now())
-)

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
@@ -19,7 +19,7 @@ data class ErrorMessage(
         val timestamp: String = DateTimeFormatter.ISO_INSTANT.format(Instant.now())
 )
 
-fun responseBuilder(userMessage: String, status: HttpStatus): ResponseEntity<ErrorMessage> {
+fun responseFactory(userMessage: String, status: HttpStatus): ResponseEntity<ErrorMessage> {
     return ResponseEntity(
         ErrorMessage(status.reasonPhrase, userMessage),
         null,
@@ -31,18 +31,17 @@ fun responseBuilder(userMessage: String, status: HttpStatus): ResponseEntity<Err
 class RestResponseExceptionHandler {
 
     @ExceptionHandler(SpecificationNotFoundException::class)
-    fun handleNotFound(exc: SpecificationNotFoundException): ResponseEntity<ErrorMessage> {
-        val detailedMessage = "Specification ${exc.specificationId} ${exc.version} not found"
-        logger.info(detailedMessage, exc)
-        return responseBuilder("Specification not found", HttpStatus.NOT_FOUND)
+    fun handleNotFound(exception: SpecificationNotFoundException): ResponseEntity<ErrorMessage> {
+        logger.info("Specification ${exception.specificationId} ${exception.version} not found", exception)
+        return responseFactory("Specification not found", HttpStatus.NOT_FOUND)
     }
 
     @ExceptionHandler(SpecificationParseException::class)
-    fun handleBadRequest(exc: SpecificationParseException) =
-            responseBuilder(exc.userMessage, HttpStatus.BAD_REQUEST)
+    fun handleBadRequest(exception: SpecificationParseException) =
+            responseFactory(exception.userMessage, HttpStatus.BAD_REQUEST)
 
     @ExceptionHandler(VersionAlreadyExistsException::class)
-    fun handleVersionAlreadyExists(exc: VersionAlreadyExistsException) =
-            responseBuilder("A specification with the same version already exists for ${exc.specificationTitle}", HttpStatus.CONFLICT)
+    fun handleVersionAlreadyExists(exception: VersionAlreadyExistsException) =
+            responseFactory("A specification with the same version already exists for ${exception.specificationTitle}", HttpStatus.CONFLICT)
 }
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
@@ -1,0 +1,48 @@
+package com.tngtech.apicenter.backend.config
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
+@ControllerAdvice
+class RestResponseExceptionHandler() {
+
+    @ExceptionHandler(SpecificationNotFoundException::class)
+    fun handleNotFound(): ResponseEntity<ErrorMessage> {
+        return ResponseEntity(
+                ErrorMessage("Specification not found"),
+                null,
+                HttpStatus.NOT_FOUND
+        )
+    }
+
+    @ExceptionHandler(SpecificationParseFailureException::class)
+    fun handleBadRequest(exc: SpecificationParseFailureException): ResponseEntity<ErrorMessage> {
+        return ResponseEntity(
+                ErrorMessage(exc.msg),
+                null,
+                HttpStatus.BAD_REQUEST
+        )
+    }
+
+    @ExceptionHandler(VersionAlreadyExistsException::class)
+    fun handleVersionAlreadyExists(exc: VersionAlreadyExistsException): ResponseEntity<ErrorMessage> {
+        return ResponseEntity(
+                ErrorMessage("A specification with the same version already exists for ${exc.specificationTitle}"),
+                null,
+                HttpStatus.UNPROCESSABLE_ENTITY
+        )
+    }
+}
+
+class SpecificationNotFoundException : RuntimeException()
+class SpecificationParseFailureException(val msg: String) : RuntimeException()
+class VersionAlreadyExistsException(val specificationTitle: String) : RuntimeException()
+
+data class ErrorMessage(
+        val message: String,
+        val timestamp: String = DateTimeFormatter.ISO_INSTANT.format(Instant.now())
+)

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
@@ -7,47 +7,43 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import mu.KotlinLogging
-import java.util.*
+import java.util.UUID
 
 private val logger = KotlinLogging.logger {  }
 class SpecificationNotFoundException(val specificationId: UUID, val version: String? = "") : RuntimeException()
-class SpecificationParseException(val msg: String) : RuntimeException()
+class SpecificationParseException(val userMessage: String) : RuntimeException()
 class VersionAlreadyExistsException(val specificationTitle: String) : RuntimeException()
 
 data class ErrorMessage(
-        val message: String,
+        val httpReasonPhrase: String,
+        val userMessage: String,
         val timestamp: String = DateTimeFormatter.ISO_INSTANT.format(Instant.now())
 )
+
+fun responseBuilder(userMessage: String, status: HttpStatus): ResponseEntity<ErrorMessage> {
+    return ResponseEntity(
+        ErrorMessage(status.reasonPhrase, userMessage),
+        null,
+        status
+    )
+}
 
 @ControllerAdvice
 class RestResponseExceptionHandler {
 
     @ExceptionHandler(SpecificationNotFoundException::class)
     fun handleNotFound(exc: SpecificationNotFoundException): ResponseEntity<ErrorMessage> {
-        logger.info("Specification ${exc.specificationId} ${exc.version} not found")
-        return ResponseEntity(
-                ErrorMessage("Specification not found"),
-                null,
-                HttpStatus.NOT_FOUND
-        )
+        val detailedMessage = "Specification ${exc.specificationId} ${exc.version} not found"
+        logger.info(detailedMessage, exc)
+        return responseBuilder("Specification not found", HttpStatus.NOT_FOUND)
     }
 
     @ExceptionHandler(SpecificationParseException::class)
-    fun handleBadRequest(exc: SpecificationParseException): ResponseEntity<ErrorMessage> {
-        return ResponseEntity(
-                ErrorMessage(exc.msg),
-                null,
-                HttpStatus.BAD_REQUEST
-        )
-    }
+    fun handleBadRequest(exc: SpecificationParseException) =
+            responseBuilder(exc.userMessage, HttpStatus.BAD_REQUEST)
 
     @ExceptionHandler(VersionAlreadyExistsException::class)
-    fun handleVersionAlreadyExists(exc: VersionAlreadyExistsException): ResponseEntity<ErrorMessage> {
-        return ResponseEntity(
-                ErrorMessage("A specification with the same version already exists for ${exc.specificationTitle}"),
-                null,
-                HttpStatus.CONFLICT
-        )
-    }
+    fun handleVersionAlreadyExists(exc: VersionAlreadyExistsException) =
+            responseBuilder("A specification with the same version already exists for ${exc.specificationTitle}", HttpStatus.CONFLICT)
 }
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
@@ -1,5 +1,8 @@
 package com.tngtech.apicenter.backend.config
 
+import com.tngtech.apicenter.backend.domain.exceptions.SpecificationNotFoundException
+import com.tngtech.apicenter.backend.domain.exceptions.SpecificationParseException
+import com.tngtech.apicenter.backend.domain.exceptions.VersionAlreadyExistsException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
@@ -7,12 +10,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import mu.KotlinLogging
-import java.util.UUID
 
 private val logger = KotlinLogging.logger {  }
-class SpecificationNotFoundException(val specificationId: UUID, val version: String? = "") : RuntimeException()
-class SpecificationParseException(val userMessage: String) : RuntimeException()
-class VersionAlreadyExistsException(val specificationTitle: String) : RuntimeException()
 
 data class ErrorMessage(
         val httpReasonPhrase: String,

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/SpecificationDatabaseService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/SpecificationDatabaseService.kt
@@ -1,6 +1,6 @@
 package com.tngtech.apicenter.backend.connector.database.service
 
-import com.tngtech.apicenter.backend.config.VersionAlreadyExistsException
+import com.tngtech.apicenter.backend.domain.exceptions.VersionAlreadyExistsException
 import com.tngtech.apicenter.backend.connector.database.entity.SpecificationEntity
 import com.tngtech.apicenter.backend.connector.database.mapper.SpecificationEntityMapper
 import com.tngtech.apicenter.backend.connector.database.repository.SpecificationRepository

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/SpecificationDatabaseService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/SpecificationDatabaseService.kt
@@ -1,5 +1,6 @@
 package com.tngtech.apicenter.backend.connector.database.service
 
+import com.tngtech.apicenter.backend.config.VersionAlreadyExistsException
 import com.tngtech.apicenter.backend.connector.database.entity.SpecificationEntity
 import com.tngtech.apicenter.backend.connector.database.mapper.SpecificationEntityMapper
 import com.tngtech.apicenter.backend.connector.database.repository.SpecificationRepository
@@ -8,11 +9,10 @@ import com.tngtech.apicenter.backend.domain.service.SpecificationPersistenceServ
 import org.hibernate.search.jpa.Search
 import org.hibernate.search.exception.EmptyQueryException
 import org.springframework.stereotype.Service
-import java.lang.Exception
-import java.lang.IllegalArgumentException
 import java.util.UUID
 import javax.persistence.EntityManager
 import javax.transaction.Transactional
+import org.springframework.dao.DataIntegrityViolationException
 
 @Service
 class SpecificationDatabaseService constructor(
@@ -70,8 +70,8 @@ class SpecificationDatabaseService constructor(
 
         try {
             specificationRepository.save(specificationEntity)
-        } catch (sqlException: Exception) {
-            throw IllegalArgumentException("This version already exists for specification ${specificationEntity.title}.", sqlException)
+        } catch (sqlException: DataIntegrityViolationException) {
+            throw VersionAlreadyExistsException(specificationEntity.title)
         }
     }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SharedRestControllerExceptions.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SharedRestControllerExceptions.kt
@@ -1,7 +1,0 @@
-package com.tngtech.apicenter.backend.connector.rest.controller
-
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.http.HttpStatus
-
-@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "Specification not found")
-class HttpNotFoundException : RuntimeException()

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
@@ -1,6 +1,6 @@
 package com.tngtech.apicenter.backend.connector.rest.controller
 
-import com.tngtech.apicenter.backend.config.SpecificationNotFoundException
+import com.tngtech.apicenter.backend.domain.exceptions.SpecificationNotFoundException
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationDto
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileDto
 import com.tngtech.apicenter.backend.connector.rest.mapper.SpecificationDtoMapper

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
@@ -62,7 +62,7 @@ class SpecificationController @Autowired constructor(
     fun findSpecification(@PathVariable specificationId: UUID): SpecificationDto {
         val specification = specificationHandler.findOne(specificationId)
         return specification?.let { specificationDtoMapper.fromDomain(it) } ?:
-            throw SpecificationNotFoundException()
+            throw SpecificationNotFoundException(specificationId)
     }
 
     @DeleteMapping("/{specificationId}")

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
@@ -1,5 +1,6 @@
 package com.tngtech.apicenter.backend.connector.rest.controller
 
+import com.tngtech.apicenter.backend.config.SpecificationNotFoundException
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationDto
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileDto
 import com.tngtech.apicenter.backend.connector.rest.mapper.SpecificationDtoMapper
@@ -58,10 +59,10 @@ class SpecificationController @Autowired constructor(
         specificationHandler.findAll().map { spec -> specificationDtoMapper.fromDomain(spec) }
 
     @GetMapping("/{specificationId}")
-    @Throws(HttpNotFoundException::class)
     fun findSpecification(@PathVariable specificationId: UUID): SpecificationDto {
         val specification = specificationHandler.findOne(specificationId)
-        return specification?.let { specificationDtoMapper.fromDomain(it) } ?: throw HttpNotFoundException()
+        return specification?.let { specificationDtoMapper.fromDomain(it) } ?:
+            throw SpecificationNotFoundException()
     }
 
     @DeleteMapping("/{specificationId}")

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionController.kt
@@ -2,6 +2,7 @@ package com.tngtech.apicenter.backend.connector.rest.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import com.tngtech.apicenter.backend.config.SpecificationNotFoundException
 
 import com.tngtech.apicenter.backend.domain.entity.Version
 import com.tngtech.apicenter.backend.connector.rest.dto.VersionDto
@@ -18,7 +19,6 @@ private const val MEDIA_TYPE_YAML = "application/yml"
 @RestController
 class VersionController constructor(private val versionHandler: VersionHandler, private val versionDtoMapper: VersionDtoMapper) {
 
-    @Throws(HttpNotFoundException::class)
     @RequestMapping("/api/v1/specifications/{specificationId}/versions/{version}",
             produces = [MediaType.APPLICATION_JSON_VALUE,
                         MEDIA_TYPE_YAML],
@@ -32,7 +32,7 @@ class VersionController constructor(private val versionHandler: VersionHandler, 
         // i.e. The integration test and unit test require the default specified in two different ways
         val foundVersion = versionHandler.findOne(specificationId, version)
         if (foundVersion == null) {
-            throw HttpNotFoundException()
+            throw SpecificationNotFoundException()
         } else if (accept == MEDIA_TYPE_YAML) {
             logger.info("Specification $specificationId version $version requested as YAML")
             val jsonNodeTree = ObjectMapper().readTree(foundVersion.content)

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionController.kt
@@ -32,7 +32,7 @@ class VersionController constructor(private val versionHandler: VersionHandler, 
         // i.e. The integration test and unit test require the default specified in two different ways
         val foundVersion = versionHandler.findOne(specificationId, version)
         if (foundVersion == null) {
-            throw SpecificationNotFoundException()
+            throw SpecificationNotFoundException(specificationId, version)
         } else if (accept == MEDIA_TYPE_YAML) {
             logger.info("Specification $specificationId version $version requested as YAML")
             val jsonNodeTree = ObjectMapper().readTree(foundVersion.content)

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionController.kt
@@ -2,7 +2,7 @@ package com.tngtech.apicenter.backend.connector.rest.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
-import com.tngtech.apicenter.backend.config.SpecificationNotFoundException
+import com.tngtech.apicenter.backend.domain.exceptions.SpecificationNotFoundException
 
 import com.tngtech.apicenter.backend.domain.entity.Version
 import com.tngtech.apicenter.backend.connector.rest.dto.VersionDto

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.jayway.jsonpath.JsonPath
 import com.jayway.jsonpath.PathNotFoundException
-import com.tngtech.apicenter.backend.config.SpecificationParseFailureException
+import com.tngtech.apicenter.backend.config.SpecificationParseException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import java.io.IOException
@@ -49,9 +49,9 @@ class SpecificationDataService @Autowired constructor(
         try {
             return JsonPath.read<String>(json, "$.info.title")
         } catch (exception: PathNotFoundException) {
-            throw SpecificationParseFailureException("Specification needs a title in the info section")
+            throw SpecificationParseException("Specification needs a title in the info section")
         } catch (exception: IllegalArgumentException) {
-            throw SpecificationParseFailureException("Specification could not be parsed as JSON")
+            throw SpecificationParseException("Specification could not be parsed as JSON")
         }
     }
 
@@ -59,9 +59,9 @@ class SpecificationDataService @Autowired constructor(
         try {
             return JsonPath.read<String>(json, "$.info.version")
         } catch (exception: PathNotFoundException) {
-            throw SpecificationParseFailureException("Specification needs a version")
+            throw SpecificationParseException("Specification needs a version")
         } catch (exception: IllegalArgumentException) {
-            throw SpecificationParseFailureException("Specification could not be parsed as JSON")
+            throw SpecificationParseException("Specification could not be parsed as JSON")
         }
     }
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.jayway.jsonpath.JsonPath
 import com.jayway.jsonpath.PathNotFoundException
+import com.tngtech.apicenter.backend.config.SpecificationParseFailureException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import java.io.IOException
+import java.lang.IllegalArgumentException
 
 @Service
 class SpecificationDataService @Autowired constructor(
@@ -47,7 +49,9 @@ class SpecificationDataService @Autowired constructor(
         try {
             return JsonPath.read<String>(json, "$.info.title")
         } catch (exception: PathNotFoundException) {
-            throw IllegalArgumentException("No title given in content.", exception)
+            throw SpecificationParseFailureException("Specification needs a title in the info section")
+        } catch (exception: IllegalArgumentException) {
+            throw SpecificationParseFailureException("Specification could not be parsed as JSON")
         }
     }
 
@@ -55,7 +59,9 @@ class SpecificationDataService @Autowired constructor(
         try {
             return JsonPath.read<String>(json, "$.info.version")
         } catch (exception: PathNotFoundException) {
-            throw IllegalArgumentException("No version given in content.", exception)
+            throw SpecificationParseFailureException("Specification needs a version")
+        } catch (exception: IllegalArgumentException) {
+            throw SpecificationParseFailureException("Specification could not be parsed as JSON")
         }
     }
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.jayway.jsonpath.JsonPath
 import com.jayway.jsonpath.PathNotFoundException
-import com.tngtech.apicenter.backend.config.SpecificationParseException
+import com.tngtech.apicenter.backend.domain.exceptions.SpecificationParseException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import java.io.IOException

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/exceptions/Exceptions.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/exceptions/Exceptions.kt
@@ -1,0 +1,7 @@
+package com.tngtech.apicenter.backend.domain.exceptions
+
+import java.util.UUID
+
+class SpecificationNotFoundException(val specificationId: UUID, val version: String? = "") : RuntimeException()
+class SpecificationParseException(val userMessage: String) : RuntimeException()
+class VersionAlreadyExistsException(val specificationTitle: String) : RuntimeException()

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataServiceTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataServiceTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.nhaarman.mockitokotlin2.given
 import com.nhaarman.mockitokotlin2.mock
-import com.tngtech.apicenter.backend.config.SpecificationParseFailureException
+import com.tngtech.apicenter.backend.config.SpecificationParseException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
@@ -54,14 +54,14 @@ class SpecificationDataServiceTest {
     @Test
     fun readTitle_shouldFailWhenNoTitleIsGiven() {
         assertThatThrownBy { specificationDataService.readTitle(SWAGGER_SPECIFICATION_WITHOUT_TITLE) }.isInstanceOf(
-            SpecificationParseFailureException::class.java
+            SpecificationParseException::class.java
         )
     }
 
     @Test
     fun readVersion_shouldFailWhenNoVersionIsGiven() {
         assertThatThrownBy { specificationDataService.readVersion(SWAGGER_SPECIFICATION_WITHOUT_VERSION) }.isInstanceOf(
-            SpecificationParseFailureException::class.java
+            SpecificationParseException::class.java
         )
     }
 

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataServiceTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataServiceTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.nhaarman.mockitokotlin2.given
 import com.nhaarman.mockitokotlin2.mock
+import com.tngtech.apicenter.backend.config.SpecificationParseFailureException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
@@ -53,15 +54,15 @@ class SpecificationDataServiceTest {
     @Test
     fun readTitle_shouldFailWhenNoTitleIsGiven() {
         assertThatThrownBy { specificationDataService.readTitle(SWAGGER_SPECIFICATION_WITHOUT_TITLE) }.isInstanceOf(
-            IllegalArgumentException::class.java
-        ).hasMessage("No title given in content.")
+            SpecificationParseFailureException::class.java
+        )
     }
 
     @Test
     fun readVersion_shouldFailWhenNoVersionIsGiven() {
         assertThatThrownBy { specificationDataService.readVersion(SWAGGER_SPECIFICATION_WITHOUT_VERSION) }.isInstanceOf(
-            IllegalArgumentException::class.java
-        ).hasMessage("No version given in content.")
+            SpecificationParseFailureException::class.java
+        )
     }
 
     @Test

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataServiceTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataServiceTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.nhaarman.mockitokotlin2.given
 import com.nhaarman.mockitokotlin2.mock
-import com.tngtech.apicenter.backend.config.SpecificationParseException
+import com.tngtech.apicenter.backend.domain.exceptions.SpecificationParseException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test

--- a/frontend/src/app/specification-form/specification-form.component.ts
+++ b/frontend/src/app/specification-form/specification-form.component.ts
@@ -98,7 +98,7 @@ export class SpecificationFormComponent implements OnInit {
       .subscribe(event => {
           this.router.navigateByUrl('/');
         },
-        error => this.error = error.error.message);
+        error => this.error = error.error.userMessage);
   }
 
   private updateSpecification(fileContent: string, fileUrl: string, specificationId: string) {
@@ -108,6 +108,6 @@ export class SpecificationFormComponent implements OnInit {
       .subscribe(event => {
           this.router.navigateByUrl('/');
         },
-        error => this.error = error.error.message);
+        error => this.error = error.error.userMessage);
   }
 }


### PR DESCRIPTION
What were bad client requests (eg. no title given in an OpenAPI specification) were all eliciting 500 code responses from the server. This also printed long stack traces in the kotlin logger.

This uses Spring's `@ControllerAdvice` to return 4xx client error codes, with the added advantage of not printing stack traces. Some thrown exceptions are made more specific. (Also, this overrides the standard Spring error response object to have a more meaningful ISO timestamp, the default one is just an integer with no indication of how to interpret its value)

The error messages are all still returned and displayed to the client correctly in the frontend.