### PR TITLE
Group specifications by ID instead of title, and x-api-id support

### DIFF
--- a/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionControllerIntegrationTest.kt
+++ b/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionControllerIntegrationTest.kt
@@ -12,7 +12,8 @@ import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @RunWith(SpringRunner::class)
 @SpringBootTest

--- a/backend/src/integration-test/resources/data.sql
+++ b/backend/src/integration-test/resources/data.sql
@@ -1,9 +1,11 @@
-INSERT INTO SPECIFICATION_ENTITY VALUES ('b6b06513d2594fafb34ba216b3daad6a', 'remoteUrl', 'Description', 'Spec1');
-INSERT INTO SPECIFICATION_ENTITY VALUES ('f67cb0a6c31b424bbfbbab0e163955ca', 'remoteUrl', 'Description', 'Spec2');
-INSERT INTO SPECIFICATION_ENTITY VALUES ('af0502a2741040e490fd3504f67de1ee', 'remoteUrl', 'Description', 'Spec3');
+INSERT INTO SPECIFICATION_ENTITY VALUES ('b6b06513-d259-4faf-b34b-a216b3daad6a', 'Description', 'remoteUrl', 'Spec1');
+INSERT INTO SPECIFICATION_ENTITY VALUES ('f67cb0a6-c31b-424b-bfbb-ab0e163955ca', 'Description', 'remoteUrl', 'Spec2');
+INSERT INTO SPECIFICATION_ENTITY VALUES ('af0502a2-7410-40e4-90fd-3504f67de1ee', 'Description', 'remoteUrl', 'Spec3');
+INSERT INTO SPECIFICATION_ENTITY VALUES ('unique-identifier',                    'Description', 'remoteUrl', 'Spec4');
 
-INSERT INTO VERSION_ENTITY VALUES('v1', '{"info": {"title": "Spec1",  "version": "v1", "description": "Description"}}' , '2018-01-01 11:00:00.000', 'Description', 'Spec1', '0', '', 'b6b06513d2594fafb34ba216b3daad6a');
-INSERT INTO VERSION_ENTITY VALUES('v1', '{"info": {"title": "Spec2",  "version": "v1", "description": "Description"}}' , '2018-01-01 11:00:00.000', 'Description', 'Spec2', '0', '', 'f67cb0a6c31b424bbfbbab0e163955ca');
-INSERT INTO VERSION_ENTITY VALUES('v2', '{"info": {"title": "Spec2",  "version": "v2", "description": "Description"}}' , '2018-01-01 10:00:00.000', 'Description', 'Spec2', '0', '', 'f67cb0a6c31b424bbfbbab0e163955ca');
-INSERT INTO VERSION_ENTITY VALUES('1.0','{"info": {"title": "Spec3",  "version": "1.0", "description": "Description"}}', '2018-01-01 11:00:00.000', 'Description', 'Spec3', '0', '', 'af0502a2741040e490fd3504f67de1ee');
-INSERT INTO VERSION_ENTITY VALUES('1.1','{"info": {"title": "Spec3",  "version": "1.1", "description": "Description"}}', '2018-01-01 10:00:00.000', 'Description', 'Spec3', '0', '', 'af0502a2741040e490fd3504f67de1ee');
+INSERT INTO VERSION_ENTITY VALUES('v1', '{"info": {"title": "Spec1",  "version": "v1", "description": "Description"}}' , '2018-01-01 11:00:00.000', 'Description', '', '0', 'Spec1', 'b6b06513-d259-4faf-b34b-a216b3daad6a');
+INSERT INTO VERSION_ENTITY VALUES('v1', '{"info": {"title": "Spec4",  "version": "v1", "description": "Description"}}' , '2018-01-01 11:00:00.000', 'Description', '', '0', 'Spec4', 'unique-identifier');
+INSERT INTO VERSION_ENTITY VALUES('v1', '{"info": {"title": "Spec2",  "version": "v1", "description": "Description"}}' , '2018-01-01 11:00:00.000', 'Description', '', '0', 'Spec2', 'f67cb0a6-c31b-424b-bfbb-ab0e163955ca');
+INSERT INTO VERSION_ENTITY VALUES('v2', '{"info": {"title": "Spec2",  "version": "v2", "description": "Description"}}' , '2018-01-01 10:00:00.000', 'Description', '', '0', 'Spec2', 'f67cb0a6-c31b-424b-bfbb-ab0e163955ca');
+INSERT INTO VERSION_ENTITY VALUES('1.0','{"info": {"title": "Spec3",  "version": "1.0", "description": "Description"}}', '2018-01-01 11:00:00.000', 'Description', '', '0', 'Spec3', 'af0502a2-7410-40e4-90fd-3504f67de1ee');
+INSERT INTO VERSION_ENTITY VALUES('1.1','{"info": {"title": "Spec3",  "version": "1.1", "description": "Description"}}', '2018-01-01 10:00:00.000', 'Description', '', '0', 'Spec3', 'af0502a2-7410-40e4-90fd-3504f67de1ee');

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
@@ -48,7 +48,7 @@ class RestResponseExceptionHandler {
                     "A-Z characters, underscores and hyphens", HttpStatus.BAD_REQUEST)
 
     @ExceptionHandler(SpecificationUploadUrlMismatch::class)
-    fun handleUnacceptableId(exception: SpecificationUploadUrlMismatch) =
+    fun handleUrlMismatch(exception: SpecificationUploadUrlMismatch) =
             responseFactory("The API ID used in the upload URL (${exception.urlPathId}) " +
                     "is not the same as the API ID used in the specification body (${exception.userDefinedId})", HttpStatus.BAD_REQUEST)
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
@@ -17,7 +17,7 @@ data class ErrorMessage(
         val timestamp: String = DateTimeFormatter.ISO_INSTANT.format(Instant.now())
 )
 
-fun responseFactory(userMessage: String, status: HttpStatus): ResponseEntity<ErrorMessage> {
+fun makeResponseEntity(userMessage: String, status: HttpStatus): ResponseEntity<ErrorMessage> {
     return ResponseEntity(
         ErrorMessage(status.reasonPhrase, userMessage),
         null,
@@ -31,25 +31,25 @@ class RestResponseExceptionHandler {
     @ExceptionHandler(SpecificationNotFoundException::class)
     fun handleNotFound(exception: SpecificationNotFoundException): ResponseEntity<ErrorMessage> {
         logger.info("Specification ${exception.specificationId} ${exception.version} not found", exception)
-        return responseFactory("Specification not found", HttpStatus.NOT_FOUND)
+        return makeResponseEntity("Specification not found", HttpStatus.NOT_FOUND)
     }
 
     @ExceptionHandler(SpecificationParseException::class)
     fun handleBadRequest(exception: SpecificationParseException) =
-            responseFactory(exception.userMessage, HttpStatus.BAD_REQUEST)
+            makeResponseEntity(exception.userMessage, HttpStatus.BAD_REQUEST)
 
     @ExceptionHandler(VersionAlreadyExistsException::class)
     fun handleVersionAlreadyExists(exception: VersionAlreadyExistsException) =
-            responseFactory("A specification with the same version already exists for ${exception.specificationTitle}", HttpStatus.CONFLICT)
+            makeResponseEntity("A specification with the same version already exists for ${exception.specificationTitle}", HttpStatus.CONFLICT)
 
     @ExceptionHandler(InvalidSpecificationIdException::class)
     fun handleUnacceptableId(exception: InvalidSpecificationIdException) =
-            responseFactory("The API ID supplied (${exception.userDefinedId}) should only contain numbers, " +
+            makeResponseEntity("The API ID supplied (${exception.userDefinedId}) should only contain numbers, " +
                     "A-Z characters, underscores and hyphens", HttpStatus.BAD_REQUEST)
 
     @ExceptionHandler(MismatchedSpecificationIdException::class)
     fun handleServiceIdMismatch(exception: MismatchedSpecificationIdException) =
-            responseFactory("The API ID used in the upload URL (${exception.urlPathId}) " +
+            makeResponseEntity("The API ID used in the upload URL (${exception.urlPathId}) " +
                     "is not the same as the API ID used in the specification body (${exception.userDefinedId})", HttpStatus.BAD_REQUEST)
 }
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
@@ -42,13 +42,13 @@ class RestResponseExceptionHandler {
     fun handleVersionAlreadyExists(exception: VersionAlreadyExistsException) =
             responseFactory("A specification with the same version already exists for ${exception.specificationTitle}", HttpStatus.CONFLICT)
 
-    @ExceptionHandler(UnacceptableUserDefinedApiId::class)
-    fun handleUnacceptableId(exception: UnacceptableUserDefinedApiId) =
+    @ExceptionHandler(InvalidSpecificationIdException::class)
+    fun handleUnacceptableId(exception: InvalidSpecificationIdException) =
             responseFactory("The API ID supplied (${exception.userDefinedId}) should only contain numbers, " +
                     "A-Z characters, underscores and hyphens", HttpStatus.BAD_REQUEST)
 
-    @ExceptionHandler(SpecificationUploadUrlMismatch::class)
-    fun handleUrlMismatch(exception: SpecificationUploadUrlMismatch) =
+    @ExceptionHandler(MismatchedSpecificationIdException::class)
+    fun handleServiceIdMismatch(exception: MismatchedSpecificationIdException) =
             responseFactory("The API ID used in the upload URL (${exception.urlPathId}) " +
                     "is not the same as the API ID used in the specification body (${exception.userDefinedId})", HttpStatus.BAD_REQUEST)
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
@@ -1,15 +1,13 @@
 package com.tngtech.apicenter.backend.config
 
-import com.tngtech.apicenter.backend.domain.exceptions.SpecificationNotFoundException
-import com.tngtech.apicenter.backend.domain.exceptions.SpecificationParseException
-import com.tngtech.apicenter.backend.domain.exceptions.VersionAlreadyExistsException
+import com.tngtech.apicenter.backend.domain.exceptions.*
+import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import java.time.Instant
 import java.time.format.DateTimeFormatter
-import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {  }
 
@@ -43,5 +41,15 @@ class RestResponseExceptionHandler {
     @ExceptionHandler(VersionAlreadyExistsException::class)
     fun handleVersionAlreadyExists(exception: VersionAlreadyExistsException) =
             responseFactory("A specification with the same version already exists for ${exception.specificationTitle}", HttpStatus.CONFLICT)
+
+    @ExceptionHandler(UnacceptableUserDefinedApiId::class)
+    fun handleUnacceptableId(exception: UnacceptableUserDefinedApiId) =
+            responseFactory("The API ID supplied (${exception.userDefinedId}) should only contain numbers, " +
+                    "A-Z characters, underscores and hyphens", HttpStatus.BAD_REQUEST)
+
+    @ExceptionHandler(SpecificationUploadUrlMismatch::class)
+    fun handleUnacceptableId(exception: SpecificationUploadUrlMismatch) =
+            responseFactory("The API ID used in the upload URL (${exception.urlPathId}) " +
+                    "is not the same as the API ID used in the specification body (${exception.userDefinedId})", HttpStatus.BAD_REQUEST)
 }
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/entity/SpecificationEntity.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/entity/SpecificationEntity.kt
@@ -7,7 +7,7 @@ import javax.persistence.*
 
 @Entity
 @Indexed
-data class SpecificationEntity(
+class SpecificationEntity(
     @Id val id: String,
     @Field val title: String,
     @Field @Column(columnDefinition = "TEXT") val description: String?,
@@ -16,4 +16,16 @@ data class SpecificationEntity(
         cascade = [CascadeType.ALL]
     ) @OrderBy("created DESC") val versions: List<VersionEntity>,
     val remoteAddress: String?
-)
+) {
+
+    fun pureUpdate(other: SpecificationEntity): SpecificationEntity {
+        val versions = this.versions + other.versions
+        return SpecificationEntity(
+                this.id,
+                other.title,
+                other.description,
+                versions,
+                other.remoteAddress
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/entity/SpecificationEntity.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/entity/SpecificationEntity.kt
@@ -3,18 +3,12 @@ package com.tngtech.apicenter.backend.connector.database.entity
 import org.hibernate.search.annotations.Field
 import org.hibernate.search.annotations.Indexed
 import org.hibernate.search.annotations.IndexedEmbedded
-import java.util.UUID
-import javax.persistence.CascadeType
-import javax.persistence.Column
-import javax.persistence.Entity
-import javax.persistence.Id
-import javax.persistence.OneToMany
-import javax.persistence.OrderBy
+import javax.persistence.*
 
 @Entity
 @Indexed
 data class SpecificationEntity(
-    @Id val id: UUID,
+    @Id val id: String,
     @Field val title: String,
     @Field @Column(columnDefinition = "TEXT") val description: String?,
     @IndexedEmbedded @OneToMany(

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/entity/VersionId.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/entity/VersionId.kt
@@ -1,15 +1,10 @@
 package com.tngtech.apicenter.backend.connector.database.entity
 
-import org.hibernate.search.annotations.ContainedIn
-import org.hibernate.search.annotations.Field
-import org.hibernate.search.annotations.Indexed
 import java.io.Serializable
-import java.util.UUID
 import javax.persistence.Embeddable
-import javax.persistence.ManyToOne
 
 @Embeddable
 data class VersionId(
-    val specificationId: UUID?,
+    val specificationId: String?,
     val version: String
 ) : Serializable

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/mapper/UserEntityMapper.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/mapper/UserEntityMapper.kt
@@ -11,4 +11,5 @@ class UserEntityMapper constructor(private val mapperFacade: MapperFacade) {
     fun toDomain(userEntity: UserEntity): User = mapperFacade.map(userEntity, User::class.java)
 
     fun fromDomain(user: User): UserEntity = mapperFacade.map(user, UserEntity::class.java)
+
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/mapper/configurer/SpecificationEntityMappingConfigurer.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/mapper/configurer/SpecificationEntityMappingConfigurer.kt
@@ -1,0 +1,18 @@
+package com.tngtech.apicenter.backend.connector.database.mapper.configurer
+
+import com.tngtech.apicenter.backend.connector.database.entity.SpecificationEntity
+import com.tngtech.apicenter.backend.domain.entity.Specification
+import ma.glasnost.orika.MapperFactory
+import net.rakugakibox.spring.boot.orika.OrikaMapperFactoryConfigurer
+import org.springframework.stereotype.Component
+
+@Component
+class SpecificationEntityMappingConfigurer: OrikaMapperFactoryConfigurer {
+
+    override fun configure(orikaMapperFactory: MapperFactory) {
+        orikaMapperFactory.classMap(SpecificationEntity::class.java, Specification::class.java)
+            .field("id", "id.id")
+            .byDefault()
+            .register()
+    }
+}

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/mapper/configurer/VersionMappingConfigurer.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/mapper/configurer/VersionMappingConfigurer.kt
@@ -16,11 +16,11 @@ class VersionMappingConfigurer constructor(private val versionConverter: Version
 
         orikaMapperFactory.classMap(VersionEntity::class.java, Version::class.java)
             .field("versionId.version", "metadata.version")
-            .field("content", "content")
             .field("title", "metadata.title")
             .field("description", "metadata.description")
             .field("language", "metadata.language")
             .field("endpointUrl", "metadata.endpointUrl")
+            .byDefault()
             .register()
     }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/mapper/converter/VersionConverter.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/mapper/converter/VersionConverter.kt
@@ -35,6 +35,7 @@ class VersionConverter : BidirectionalConverter<Version, VersionEntity>() {
                         source.metadata.language,
                         source.metadata.endpointUrl,
                         null,
-                        null)
+                        null
+        )
     }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/repository/SpecificationRepository.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/repository/SpecificationRepository.kt
@@ -3,11 +3,11 @@ package com.tngtech.apicenter.backend.connector.database.repository
 import com.tngtech.apicenter.backend.connector.database.entity.SpecificationEntity
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
-import java.util.UUID
+import java.util.*
 
 @Repository
-interface SpecificationRepository : CrudRepository<SpecificationEntity, UUID> {
+interface SpecificationRepository : CrudRepository<SpecificationEntity, String> {
 
-    fun existsByTitle(title: String): Boolean
-    fun findByTitle(title: String): SpecificationEntity
+    override fun existsById(id: String): Boolean
+    override fun findById(id: String): Optional<SpecificationEntity>
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/SpecificationDatabaseService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/SpecificationDatabaseService.kt
@@ -3,6 +3,7 @@ package com.tngtech.apicenter.backend.connector.database.service
 import com.tngtech.apicenter.backend.connector.database.entity.SpecificationEntity
 import com.tngtech.apicenter.backend.connector.database.mapper.SpecificationEntityMapper
 import com.tngtech.apicenter.backend.connector.database.repository.SpecificationRepository
+import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Specification
 import com.tngtech.apicenter.backend.domain.exceptions.VersionAlreadyExistsException
 import com.tngtech.apicenter.backend.domain.service.SpecificationPersistenceService
@@ -10,7 +11,6 @@ import org.hibernate.search.exception.EmptyQueryException
 import org.hibernate.search.jpa.Search
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
-import java.util.*
 import javax.persistence.EntityManager
 import javax.transaction.Transactional
 
@@ -22,32 +22,24 @@ class SpecificationDatabaseService constructor(
 ) : SpecificationPersistenceService {
 
     override fun save(specification: Specification) {
-        val specificationEntity = specificationEntityMapper.fromDomain(specification)
+        val newEntity = specificationEntityMapper.fromDomain(specification)
 
-        val entityToStore = specificationRepository.findById(specificationEntity.id).map {
-            existingEntity ->
-            val versions = existingEntity.versions + specificationEntity.versions
-            SpecificationEntity(
-                existingEntity.id,
-                specificationEntity.title,
-                specificationEntity.description,
-                versions,
-                specificationEntity.remoteAddress
-            )
-        }.orElse(specificationEntity)
+        val entityToStore = specificationRepository.findById(newEntity.id)
+            .map { existingEntity -> existingEntity.pureUpdate(newEntity)}
+            .orElse(newEntity)
 
         mapAndStoreEntity(entityToStore)
     }
 
     override fun findAll(): List<Specification> = specificationRepository.findAll().map { spec -> specificationEntityMapper.toDomain(spec) }
 
-    override fun findOne(id: String): Specification? =
-        specificationRepository.findById(id).orElse(null)?.let { spec -> specificationEntityMapper.toDomain(spec) }
+    override fun findOne(id: ServiceId): Specification? =
+        specificationRepository.findById(id.id).orElse(null)?.let { spec -> specificationEntityMapper.toDomain(spec) }
 
-    override fun delete(id: String) = specificationRepository.deleteById(id)
+    override fun delete(id: ServiceId) = specificationRepository.deleteById(id.id)
 
-    override fun exists(id: String): Boolean =
-        specificationRepository.existsById(id)
+    override fun exists(id: ServiceId): Boolean =
+        specificationRepository.existsById(id.id)
 
     @Transactional
     override fun search(searchString: String): List<Specification> {

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/SpecificationDatabaseService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/SpecificationDatabaseService.kt
@@ -27,7 +27,13 @@ class SpecificationDatabaseService constructor(
         val entityToStore = specificationRepository.findById(specificationEntity.id).map {
             existingEntity ->
             val versions = existingEntity.versions + specificationEntity.versions
-            SpecificationEntity(existingEntity.id, existingEntity.title, existingEntity.description, versions, existingEntity.remoteAddress)
+            SpecificationEntity(
+                existingEntity.id,
+                specificationEntity.title,
+                specificationEntity.description,
+                versions,
+                specificationEntity.remoteAddress
+            )
         }.orElse(specificationEntity)
 
         mapAndStoreEntity(entityToStore)

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/VersionDatabaseService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/VersionDatabaseService.kt
@@ -6,7 +6,6 @@ import com.tngtech.apicenter.backend.connector.database.repository.VersionReposi
 import com.tngtech.apicenter.backend.domain.entity.Version
 import com.tngtech.apicenter.backend.domain.service.VersionPersistenceService
 import org.springframework.stereotype.Service
-import java.util.UUID
 
 @Service
 class VersionDatabaseService constructor(
@@ -14,12 +13,12 @@ class VersionDatabaseService constructor(
     private val versionEntityMapper: VersionEntityMapper
 ) : VersionPersistenceService {
 
-    override fun findOne(specificationId: UUID, versionTitle: String): Version? {
+    override fun findOne(specificationId: String, versionTitle: String): Version? {
         return versionRepository.findById(VersionId(specificationId, versionTitle)).orElse(null)?.let { version -> versionEntityMapper.toDomain(version) }
     }
 
 
-    override fun delete(specificationId: UUID, versionTitle: String) {
+    override fun delete(specificationId: String, versionTitle: String) {
         versionRepository.deleteById(VersionId(specificationId, versionTitle))
     }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/VersionDatabaseService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/VersionDatabaseService.kt
@@ -3,6 +3,7 @@ package com.tngtech.apicenter.backend.connector.database.service
 import com.tngtech.apicenter.backend.connector.database.entity.VersionId
 import com.tngtech.apicenter.backend.connector.database.mapper.VersionEntityMapper
 import com.tngtech.apicenter.backend.connector.database.repository.VersionRepository
+import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Version
 import com.tngtech.apicenter.backend.domain.service.VersionPersistenceService
 import org.springframework.stereotype.Service
@@ -13,12 +14,12 @@ class VersionDatabaseService constructor(
     private val versionEntityMapper: VersionEntityMapper
 ) : VersionPersistenceService {
 
-    override fun findOne(specificationId: String, versionTitle: String): Version? {
-        return versionRepository.findById(VersionId(specificationId, versionTitle)).orElse(null)?.let { version -> versionEntityMapper.toDomain(version) }
+    override fun findOne(specificationId: ServiceId, versionTitle: String): Version? {
+        return versionRepository.findById(VersionId(specificationId.id, versionTitle)).orElse(null)?.let { version -> versionEntityMapper.toDomain(version) }
     }
 
 
-    override fun delete(specificationId: String, versionTitle: String) {
-        versionRepository.deleteById(VersionId(specificationId, versionTitle))
+    override fun delete(specificationId: ServiceId, versionTitle: String) {
+        versionRepository.deleteById(VersionId(specificationId.id, versionTitle))
     }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
@@ -49,12 +49,11 @@ class SpecificationController @Autowired constructor(
     }
 
     private fun getConsistentId(specificationFileDto: SpecificationFileDto, specificationIdFromPath: String): String {
-        return specificationFileDto.id?.let {
-            idFromFile -> if (idFromFile == specificationIdFromPath) specificationIdFromPath
-                      else throw MismatchedSpecificationIdException(idFromFile, specificationIdFromPath)
-        } ?: run {
-            specificationIdFromPath
+        specificationFileDto.id?.let {
+            idFromFile -> if (idFromFile != specificationIdFromPath)
+                throw MismatchedSpecificationIdException(idFromFile, specificationIdFromPath)
         }
+        return specificationIdFromPath
     }
 
     @GetMapping

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationController.kt
@@ -1,23 +1,15 @@
 package com.tngtech.apicenter.backend.connector.rest.controller
 
-import com.tngtech.apicenter.backend.domain.exceptions.SpecificationNotFoundException
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationDto
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileDto
 import com.tngtech.apicenter.backend.connector.rest.mapper.SpecificationDtoMapper
 import com.tngtech.apicenter.backend.connector.rest.service.SynchronizationService
 import com.tngtech.apicenter.backend.domain.service.SpecificationPersistenceService
+import com.tngtech.apicenter.backend.domain.exceptions.SpecificationNotFoundException
+import com.tngtech.apicenter.backend.domain.exceptions.SpecificationUploadUrlMismatch
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
-import java.util.*
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/specifications")
@@ -37,15 +29,22 @@ class SpecificationController @Autowired constructor(
         return specificationDtoMapper.fromDomain(specification)
     }
 
-    @PutMapping("/{specificationId}")
-    fun updateSpecification(@RequestBody specificationFileDto: SpecificationFileDto, @PathVariable specificationId: String): SpecificationDto {
+    @PutMapping("/{urlPathId}")
+    fun updateSpecification(@RequestBody specificationFileDto: SpecificationFileDto, @PathVariable urlPathId: String): SpecificationDto {
+
+        val specificationId = specificationFileDto.id?.let {
+            userId -> if (userId == urlPathId) urlPathId
+                      else throw SpecificationUploadUrlMismatch(userId, urlPathId)
+        } ?: run {
+            urlPathId
+        }
 
         val specification = specificationDtoMapper.toDomain(
             SpecificationFileDto(
                 specificationFileDto.fileContent,
                 specificationFileDto.fileUrl,
                 specificationFileDto.metaData,
-                UUID.fromString(specificationId)
+                specificationId
             )
         )
 
@@ -59,19 +58,19 @@ class SpecificationController @Autowired constructor(
         specificationPersistenceService.findAll().map { spec -> specificationDtoMapper.fromDomain(spec) }
 
     @GetMapping("/{specificationId}")
-    fun findSpecification(@PathVariable specificationId: UUID): SpecificationDto {
+    fun findSpecification(@PathVariable specificationId: String): SpecificationDto {
         val specification = specificationPersistenceService.findOne(specificationId)
         return specification?.let { specificationDtoMapper.fromDomain(it) } ?:
             throw SpecificationNotFoundException(specificationId)
     }
 
     @DeleteMapping("/{specificationId}")
-    fun deleteSpecification(@PathVariable specificationId: UUID) {
+    fun deleteSpecification(@PathVariable specificationId: String) {
         specificationPersistenceService.delete(specificationId)
     }
 
     @PostMapping("/{specificationId}/synchronize")
-    fun synchronizeSpecification(@PathVariable specificationId: UUID) {
+    fun synchronizeSpecification(@PathVariable specificationId: String) {
         synchronizationService.synchronize(specificationId)
     }
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionController.kt
@@ -2,15 +2,13 @@ package com.tngtech.apicenter.backend.connector.rest.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
-import com.tngtech.apicenter.backend.domain.exceptions.SpecificationNotFoundException
-
-import com.tngtech.apicenter.backend.domain.entity.Version
 import com.tngtech.apicenter.backend.connector.rest.dto.VersionDto
 import com.tngtech.apicenter.backend.connector.rest.mapper.VersionDtoMapper
 import com.tngtech.apicenter.backend.domain.service.VersionPersistenceService
 import org.springframework.web.bind.annotation.*
 import org.springframework.http.MediaType
-import java.util.UUID
+import com.tngtech.apicenter.backend.domain.entity.Version
+import com.tngtech.apicenter.backend.domain.exceptions.SpecificationNotFoundException
 import mu.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
@@ -25,27 +23,28 @@ class VersionController constructor(private val versionPersistenceService: Versi
             headers =  ["Accept=" + MediaType.APPLICATION_JSON_VALUE,
                         "Accept=" + MEDIA_TYPE_YAML],
             method =   [RequestMethod.GET])
-    fun findVersion(@PathVariable specificationId: UUID,
+    fun findVersion(@PathVariable specificationId: String,
                     @PathVariable version: String,
                     @RequestHeader(value = "Accept",
                                    defaultValue = MediaType.APPLICATION_JSON_VALUE) accept: String = MediaType.APPLICATION_JSON_VALUE): VersionDto {
         // i.e. The integration test and unit test require the default specified in two different ways
-        val foundVersion = versionPersistenceService.findOne(specificationId, version)
-        if (foundVersion == null) {
-            throw SpecificationNotFoundException(specificationId, version)
-        } else if (accept == MEDIA_TYPE_YAML) {
+        val foundVersion = versionPersistenceService.findOne(specificationId, version) ?: throw SpecificationNotFoundException(specificationId, version)
+
+        val convertedVersion = if (accept == MEDIA_TYPE_YAML) {
             logger.info("Specification $specificationId version $version requested as YAML")
             val jsonNodeTree = ObjectMapper().readTree(foundVersion.content)
             val jsonAsYaml = YAMLMapper().writeValueAsString(jsonNodeTree)
-            return versionDtoMapper.fromDomain(Version(jsonAsYaml, foundVersion.metadata))
+            Version(jsonAsYaml, foundVersion.metadata)
         } else {
             logger.info("Specification $specificationId version $version requested as JSON")
-            return versionDtoMapper.fromDomain(foundVersion)
+            foundVersion
         }
+
+        return versionDtoMapper.fromDomain(convertedVersion)
     }
 
     @DeleteMapping("/api/v1/specifications/{specificationId}/versions/{version}")
-    fun deleteVersion(@PathVariable specificationId: UUID, @PathVariable version: String) {
+    fun deleteVersion(@PathVariable specificationId: String, @PathVariable version: String) {
         versionPersistenceService.delete(specificationId, version)
     }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationDto.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationDto.kt
@@ -1,9 +1,7 @@
 package com.tngtech.apicenter.backend.connector.rest.dto
 
-import java.util.UUID
-
 data class SpecificationDto(
-    val id: UUID,
+    val id: String,
     val title: String,
     val description: String?,
     val versions: List<VersionDto>,

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationFileDto.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationFileDto.kt
@@ -2,7 +2,6 @@ package com.tngtech.apicenter.backend.connector.rest.dto
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
-import java.util.UUID
 
 data class SpecificationMetaData constructor(
     val title: String,
@@ -16,5 +15,5 @@ data class SpecificationFileDto @JsonCreator constructor(
     val fileContent: String?,
     val fileUrl: String? = "",
     val metaData: SpecificationMetaData? = null,
-    val id: UUID? = null
+    val id: String? = null
 )

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/configurer/SpecificationFileDtoMappingConfigurer.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/configurer/SpecificationFileDtoMappingConfigurer.kt
@@ -2,24 +2,26 @@ package com.tngtech.apicenter.backend.connector.rest.mapper.configurer
 
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationDto
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileDto
-import com.tngtech.apicenter.backend.connector.rest.mapper.converter.SpecificationConverter
+import com.tngtech.apicenter.backend.connector.rest.mapper.converter.SpecificationFileDtoConverter
 import com.tngtech.apicenter.backend.domain.entity.Specification
 import ma.glasnost.orika.MapperFactory
 import net.rakugakibox.spring.boot.orika.OrikaMapperFactoryConfigurer
 import org.springframework.stereotype.Component
 
 @Component
-class SpecificationFileDtoMappingConfigurer constructor(private val specificationConverter: SpecificationConverter) :
+class SpecificationFileDtoMappingConfigurer constructor(private val specificationFileDtoConverter: SpecificationFileDtoConverter) :
     OrikaMapperFactoryConfigurer {
 
     override fun configure(orikaMapperFactory: MapperFactory) {
         orikaMapperFactory.classMap(Specification::class.java, SpecificationDto::class.java)
+            .field("id.id", "id")
             .byDefault()
             .register()
 
         orikaMapperFactory.classMap(SpecificationFileDto::class.java, Specification::class.java)
+            .field("id", "id.id")
             .byDefault()
 
-        orikaMapperFactory.converterFactory.registerConverter(specificationConverter)
+        orikaMapperFactory.converterFactory.registerConverter(specificationFileDtoConverter)
     }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/configurer/SpecificationFileDtoMappingConfigurer.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/configurer/SpecificationFileDtoMappingConfigurer.kt
@@ -9,7 +9,7 @@ import net.rakugakibox.spring.boot.orika.OrikaMapperFactoryConfigurer
 import org.springframework.stereotype.Component
 
 @Component
-class SpecificationMappingConfigurer constructor(private val specificationConverter: SpecificationConverter) :
+class SpecificationFileDtoMappingConfigurer constructor(private val specificationConverter: SpecificationConverter) :
     OrikaMapperFactoryConfigurer {
 
     override fun configure(orikaMapperFactory: MapperFactory) {

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationConverter.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationConverter.kt
@@ -9,7 +9,6 @@ import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Specification
 import com.tngtech.apicenter.backend.domain.entity.Version
 import com.tngtech.apicenter.backend.domain.exceptions.MismatchedSpecificationIdException
-import com.tngtech.apicenter.backend.domain.exceptions.InvalidSpecificationIdException
 import ma.glasnost.orika.CustomConverter
 import ma.glasnost.orika.MappingContext
 import ma.glasnost.orika.metadata.Type
@@ -33,7 +32,7 @@ class SpecificationConverter constructor(
         val parsedFileContent = if (specificationFileDto.metaData != null) fileContent
                                 else specificationDataService.parseFileContent(fileContent)
 
-        val metadata = specificationFileDto.metaData ?: metadataFactory(parsedFileContent)
+        val metadata = specificationFileDto.metaData ?: makeSpecificationMetaData(parsedFileContent)
 
         val idFromUpload = specificationDataService.extractId(parsedFileContent)
         val idFromPath = specificationFileDto.id
@@ -63,7 +62,7 @@ class SpecificationConverter constructor(
         return ServiceId(idFromUpload ?: idFromPath ?: UUID.randomUUID().toString())
     }
 
-    private fun metadataFactory(fileContent: String): SpecificationMetaData {
+    private fun makeSpecificationMetaData(fileContent: String): SpecificationMetaData {
         return SpecificationMetaData(
             specificationDataService.extractTitle(fileContent),
             specificationDataService.extractVersion(fileContent),

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationConverter.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationConverter.kt
@@ -5,10 +5,11 @@ import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationMetaData
 import com.tngtech.apicenter.backend.connector.rest.service.SpecificationDataService
 import com.tngtech.apicenter.backend.connector.rest.service.SpecificationFileService
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
+import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Specification
 import com.tngtech.apicenter.backend.domain.entity.Version
-import com.tngtech.apicenter.backend.domain.exceptions.SpecificationUploadUrlMismatch
-import com.tngtech.apicenter.backend.domain.exceptions.UnacceptableUserDefinedApiId
+import com.tngtech.apicenter.backend.domain.exceptions.MismatchedSpecificationIdException
+import com.tngtech.apicenter.backend.domain.exceptions.InvalidSpecificationIdException
 import ma.glasnost.orika.CustomConverter
 import ma.glasnost.orika.MappingContext
 import ma.glasnost.orika.metadata.Type
@@ -27,54 +28,48 @@ class SpecificationConverter constructor(
         destinationType: Type<out Specification>?,
         mappingContext: MappingContext?
     ): Specification {
-        var fileContent = specificationFileDto.fileContent ?: ""
-        val dtoMetadata = specificationFileDto.metaData
-        val isGraphQLFile = dtoMetadata != null
+        val fileContent = getLocalOrRemoteFileContent(specificationFileDto)
 
-        if (specificationFileDto.fileUrl != null && specificationFileDto.fileUrl != "") {
-            fileContent = specificationFileService.retrieveFile(specificationFileDto.fileUrl)
-        }
+        val parsedFileContent = if (specificationFileDto.metaData != null) fileContent
+                                else specificationDataService.parseFileContent(fileContent)
 
-        val content = if (isGraphQLFile) fileContent else specificationDataService.parseFileContent(fileContent)
+        val metadata = specificationFileDto.metaData ?: metadataFactory(parsedFileContent)
 
-        val userDefinedId = specificationDataService.readId(content)
-        val urlPathId = specificationFileDto.id
-
-        if (userDefinedId?.let { userId -> !isAcceptable(userId) } ?: run { false } ) {
-            throw UnacceptableUserDefinedApiId(userDefinedId!!)
-        }
-
-        if (userDefinedId?.let { userId -> urlPathId?.let { urlId -> urlId != userId } } ?: run { false } ) {
-            throw SpecificationUploadUrlMismatch(userDefinedId!!, urlPathId!!)
-        }
-
-        val uuid = userDefinedId ?: urlPathId ?: UUID.randomUUID().toString()
-
-        // If metadata is present, we use it. Otherwise, we build one from reading the content the client sends
-        val metadata = dtoMetadata ?: SpecificationMetaData(
-            specificationDataService.readTitle(content),
-            specificationDataService.readVersion(content),
-            specificationDataService.readDescription(content),
-            ApiLanguage.OPENAPI,
-            null
-        )
+        val idFromUpload = specificationDataService.extractId(parsedFileContent)
+        val idFromPath = specificationFileDto.id
+        val serviceId = getConsistentServiceId(idFromUpload, idFromPath)
 
         return Specification(
-            uuid,
+            serviceId,
             metadata.title,
             metadata.description,
-            listOf(Version(content, metadata)),
+            listOf(Version(parsedFileContent, metadata)),
             specificationFileDto.fileUrl
         )
     }
 
-    private fun isAcceptable(userId: String): Boolean {
-        // This is quite conservative.
-        // An 'unacceptable' ID for this purpose is one that cannot be subsequently retrieved from the repository
-        //   because the ID in the browser URI path does not match the ID in the specification
-        // Some characters are escaped automatically, eg. '/' (http://localhost:4200/specifications/unique%2Fidentifier/0.1.8)
-        // Some special characters (äöü§) are not, but still result in the same problem
-        //   perhaps these are escaped at a different pipeline stage of URI processing
-        return userId.matches("^[\\w_\\-]+$".toRegex())
+    private fun getLocalOrRemoteFileContent(specificationFileDto: SpecificationFileDto): String {
+        return if (specificationFileDto.fileUrl != null && specificationFileDto.fileUrl != "") {
+            specificationFileService.retrieveFile(specificationFileDto.fileUrl)
+        } else {
+            specificationFileDto.fileContent ?: ""
+        }
+    }
+
+    private fun getConsistentServiceId(idFromUpload: String?, idFromPath: String?): ServiceId {
+        if (idFromUpload != null && idFromPath != null && idFromUpload != idFromPath) {
+            throw MismatchedSpecificationIdException(idFromUpload, idFromPath)
+        }
+        return ServiceId(idFromUpload ?: idFromPath ?: UUID.randomUUID().toString())
+    }
+
+    private fun metadataFactory(fileContent: String): SpecificationMetaData {
+        return SpecificationMetaData(
+            specificationDataService.extractTitle(fileContent),
+            specificationDataService.extractVersion(fileContent),
+            specificationDataService.extractDescription(fileContent),
+            ApiLanguage.OPENAPI,
+            null
+        )
     }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationFileDtoConverter.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationFileDtoConverter.kt
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component
 import java.util.*
 
 @Component
-class SpecificationConverter constructor(
+class SpecificationFileDtoConverter constructor(
     private val specificationFileService: SpecificationFileService,
     private val specificationDataService: SpecificationDataService
 ) :

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
@@ -44,7 +44,7 @@ class SpecificationDataService @Autowired constructor(
         }
     }
 
-    fun readTitle(json: String): String {
+    fun extractTitle(json: String): String {
         try {
             return JsonPath.read<String>(json, "$.info.title")
         } catch (exception: PathNotFoundException) {
@@ -54,7 +54,7 @@ class SpecificationDataService @Autowired constructor(
         }
     }
 
-    fun readVersion(json: String): String {
+    fun extractVersion(json: String): String {
         try {
             return JsonPath.read<String>(json, "$.info.version")
         } catch (exception: PathNotFoundException) {
@@ -64,15 +64,14 @@ class SpecificationDataService @Autowired constructor(
         }
     }
 
-    fun readDescription(json: String): String? =
-        // Not a required field in the OpenAPI spec
+    fun extractDescription(json: String): String? =
         try {
             JsonPath.read<String>(json, "$.info.description")
         } catch (exception: PathNotFoundException) {
             null
         }
 
-    fun readId(json: String): String? =
+    fun extractId(json: String): String? =
         try {
             JsonPath.read<String>(json, "$.info.x-api-id")
         } catch (exception: PathNotFoundException) {

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
@@ -8,7 +8,6 @@ import com.tngtech.apicenter.backend.domain.exceptions.SpecificationParseExcepti
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import java.io.IOException
-import java.lang.IllegalArgumentException
 
 @Service
 class SpecificationDataService @Autowired constructor(
@@ -69,6 +68,13 @@ class SpecificationDataService @Autowired constructor(
         // Not a required field in the OpenAPI spec
         try {
             JsonPath.read<String>(json, "$.info.description")
+        } catch (exception: PathNotFoundException) {
+            null
+        }
+
+    fun readId(json: String): String? =
+        try {
+            JsonPath.read<String>(json, "$.info.x-api-id")
         } catch (exception: PathNotFoundException) {
             null
         }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SynchronizationService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SynchronizationService.kt
@@ -2,6 +2,7 @@ package com.tngtech.apicenter.backend.connector.rest.service
 
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationMetaData
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
+import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Specification
 import com.tngtech.apicenter.backend.domain.entity.Version
 import com.tngtech.apicenter.backend.domain.service.SpecificationPersistenceService
@@ -14,14 +15,14 @@ class SynchronizationService constructor(
     private val specificationDataService: SpecificationDataService
 ) {
 
-    fun synchronize(specificationId: String) {
+    fun synchronize(specificationId: ServiceId) {
         val specification = specificationPersistenceService.findOne(specificationId)!!
 
         val remoteAddress = specification.remoteAddress ?: ""
 
         val fileContent = specificationFileService.retrieveFile(remoteAddress)
         val content = specificationDataService.parseFileContent(fileContent)
-        val versionString = specificationDataService.readVersion(content)
+        val versionString = specificationDataService.extractVersion(content)
 
         val versions = if (specification.versions.find { version -> version.metadata.version == versionString } != null) {
             specification.versions
@@ -32,8 +33,8 @@ class SynchronizationService constructor(
 
         val newSpecification = Specification(
             specification.id,
-            specificationDataService.readTitle(content),
-            specificationDataService.readDescription(content),
+            specificationDataService.extractTitle(content),
+            specificationDataService.extractDescription(content),
             versions,
             specification.remoteAddress
         )

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SynchronizationService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SynchronizationService.kt
@@ -6,7 +6,6 @@ import com.tngtech.apicenter.backend.domain.entity.Specification
 import com.tngtech.apicenter.backend.domain.entity.Version
 import com.tngtech.apicenter.backend.domain.service.SpecificationPersistenceService
 import org.springframework.stereotype.Service
-import java.util.UUID
 
 @Service
 class SynchronizationService constructor(
@@ -15,7 +14,7 @@ class SynchronizationService constructor(
     private val specificationDataService: SpecificationDataService
 ) {
 
-    fun synchronize(specificationId: UUID) {
+    fun synchronize(specificationId: String) {
         val specification = specificationPersistenceService.findOne(specificationId)!!
 
         val remoteAddress = specification.remoteAddress ?: ""

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/ServiceId.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/ServiceId.kt
@@ -1,0 +1,28 @@
+package com.tngtech.apicenter.backend.domain.entity
+
+import com.tngtech.apicenter.backend.domain.exceptions.InvalidSpecificationIdException
+
+class ServiceId {
+    val id: String
+
+    constructor(id: String) {
+        if (containsInvalidCharacters(id)) throw InvalidSpecificationIdException(id)
+        this.id = id
+    }
+
+    private fun containsInvalidCharacters(id: String): Boolean {
+        return !id.matches("^[\\w_\\-]+$".toRegex())
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return if (other == null || other::class != this::class) {
+            false
+        } else {
+            this.id == (other as ServiceId).id
+        }
+    }
+
+    override fun hashCode(): Int {
+        return this.id.hashCode()
+    }
+}

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Specification.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Specification.kt
@@ -1,13 +1,11 @@
 package com.tngtech.apicenter.backend.domain.entity
 
-import java.util.UUID
-
 enum class ApiLanguage {
     OPENAPI, GRAPHQL
 }
 
 data class Specification(
-    val id: UUID,
+    val id: String,
     val title: String,
     val description: String?,
     val versions: List<Version>,

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Specification.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Specification.kt
@@ -5,7 +5,7 @@ enum class ApiLanguage {
 }
 
 data class Specification(
-    val id: String,
+    val id: ServiceId,
     val title: String,
     val description: String?,
     val versions: List<Version>,

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/exceptions/Exceptions.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/exceptions/Exceptions.kt
@@ -1,7 +1,7 @@
 package com.tngtech.apicenter.backend.domain.exceptions
 
-import java.util.UUID
-
-class SpecificationNotFoundException(val specificationId: UUID, val version: String? = "") : RuntimeException()
+class SpecificationNotFoundException(val specificationId: String, val version: String? = "") : RuntimeException()
 class SpecificationParseException(val userMessage: String) : RuntimeException()
 class VersionAlreadyExistsException(val specificationTitle: String) : RuntimeException()
+class UnacceptableUserDefinedApiId(val userDefinedId: String): RuntimeException()
+class SpecificationUploadUrlMismatch(val userDefinedId: String, val urlPathId: String): RuntimeException()

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/exceptions/Exceptions.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/exceptions/Exceptions.kt
@@ -3,5 +3,5 @@ package com.tngtech.apicenter.backend.domain.exceptions
 class SpecificationNotFoundException(val specificationId: String, val version: String? = "") : RuntimeException()
 class SpecificationParseException(val userMessage: String) : RuntimeException()
 class VersionAlreadyExistsException(val specificationTitle: String) : RuntimeException()
-class UnacceptableUserDefinedApiId(val userDefinedId: String): RuntimeException()
-class SpecificationUploadUrlMismatch(val userDefinedId: String, val urlPathId: String): RuntimeException()
+class InvalidSpecificationIdException(val userDefinedId: String): RuntimeException()
+class MismatchedSpecificationIdException(val userDefinedId: String, val urlPathId: String): RuntimeException()

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/service/SpecificationPersistenceService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/service/SpecificationPersistenceService.kt
@@ -1,13 +1,12 @@
 package com.tngtech.apicenter.backend.domain.service
 
 import com.tngtech.apicenter.backend.domain.entity.Specification
-import java.util.UUID
 
 interface SpecificationPersistenceService {
     fun save(specification: Specification)
     fun findAll(): List<Specification>
-    fun findOne(id: UUID): Specification?
-    fun delete(id: UUID)
-    fun exists(id: UUID): Boolean
+    fun findOne(id: String): Specification?
+    fun delete(id: String)
+    fun exists(id: String): Boolean
     fun search(searchString: String): List<Specification>
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/service/SpecificationPersistenceService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/service/SpecificationPersistenceService.kt
@@ -1,12 +1,13 @@
 package com.tngtech.apicenter.backend.domain.service
 
+import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Specification
 
 interface SpecificationPersistenceService {
     fun save(specification: Specification)
     fun findAll(): List<Specification>
-    fun findOne(id: String): Specification?
-    fun delete(id: String)
-    fun exists(id: String): Boolean
+    fun findOne(id: ServiceId): Specification?
+    fun delete(id: ServiceId)
+    fun exists(id: ServiceId): Boolean
     fun search(searchString: String): List<Specification>
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/service/VersionPersistenceService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/service/VersionPersistenceService.kt
@@ -1,8 +1,9 @@
 package com.tngtech.apicenter.backend.domain.service
 
+import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Version
 
 interface VersionPersistenceService {
-    fun findOne(specificationId: String, versionTitle: String): Version?
-    fun delete(specificationId: String, versionTitle: String)
+    fun findOne(specificationId: ServiceId, versionTitle: String): Version?
+    fun delete(specificationId: ServiceId, versionTitle: String)
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/service/VersionPersistenceService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/service/VersionPersistenceService.kt
@@ -1,9 +1,8 @@
 package com.tngtech.apicenter.backend.domain.service
 
 import com.tngtech.apicenter.backend.domain.entity.Version
-import java.util.UUID
 
 interface VersionPersistenceService {
-    fun findOne(specificationId: UUID, versionTitle: String): Version?
-    fun delete(specificationId: UUID, versionTitle: String)
+    fun findOne(specificationId: String, versionTitle: String): Version?
+    fun delete(specificationId: String, versionTitle: String)
 }

--- a/backend/src/main/resources/api-definition.json
+++ b/backend/src/main/resources/api-definition.json
@@ -185,8 +185,7 @@
             "in": "path",
             "description": "specificationId",
             "required": true,
-            "type": "string",
-            "format": "uuid"
+            "type": "string"
           },
           {
             "in": "header",
@@ -300,8 +299,7 @@
             "in": "path",
             "description": "specificationId",
             "required": true,
-            "type": "string",
-            "format": "uuid"
+            "type": "string"
           },
           {
             "in": "header",
@@ -345,8 +343,7 @@
             "in": "path",
             "description": "specificationId",
             "required": true,
-            "type": "string",
-            "format": "uuid"
+            "type": "string"
           },
           {
             "in": "header",
@@ -389,16 +386,14 @@
             "in": "path",
             "description": "The ID of the specification for which the version should be fetched.",
             "required": true,
-            "type": "string",
-            "format": "uuid"
+            "type": "string"
           },
           {
             "name": "version",
             "in": "path",
             "description": "The version that should be fetched",
             "required": true,
-            "type": "string",
-            "format": "uuid"
+            "type": "string"
           },
           {
             "in": "header",
@@ -445,16 +440,14 @@
             "in": "path",
             "description": "The ID of the specification for which the version should be deleted.",
             "required": true,
-            "type": "string",
-            "format": "uuid"
+            "type": "string"
           },
           {
             "name": "version",
             "in": "path",
             "description": "The version that should be deleted",
             "required": true,
-            "type": "string",
-            "format": "uuid"
+            "type": "string"
           }
         ],
         "responses": {
@@ -517,8 +510,7 @@
             "type": "string"
           },
           "id": {
-            "type": "string",
-            "format": "uuid"
+            "type": "string"
           },
           "remoteAddress": {
             "type": "string"
@@ -540,8 +532,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "format": "uuid",
-            "description": "The uuid of an already existing specification",
+            "description": "The id of an already existing specification",
             "required": false
           }
         },

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerUnitTest.kt
@@ -9,6 +9,7 @@ import com.tngtech.apicenter.backend.connector.rest.dto.VersionDto
 import com.tngtech.apicenter.backend.connector.rest.mapper.SpecificationDtoMapper
 import com.tngtech.apicenter.backend.connector.rest.service.SynchronizationService
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
+import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Specification
 import com.tngtech.apicenter.backend.domain.entity.Version
 import com.tngtech.apicenter.backend.domain.service.SpecificationPersistenceService
@@ -44,7 +45,7 @@ internal class SpecificationControllerUnitTest {
             SpecificationFileDto(SWAGGER_SPECIFICATION)
 
         val specification = Specification(
-            UUID_STRING,
+            ServiceId(UUID_STRING),
             "Swagger Petstore",
             "Description",
             listOf(Version(SWAGGER_SPECIFICATION, metadata)),
@@ -76,7 +77,7 @@ internal class SpecificationControllerUnitTest {
                 UUID_STRING
             )
         val specification = Specification(
-            UUID_STRING,
+            ServiceId(UUID_STRING),
             "Swagger Petstore",
             "Description",
             listOf(Version(SWAGGER_SPECIFICATION, metadata)),
@@ -113,7 +114,7 @@ internal class SpecificationControllerUnitTest {
         val uuid = UUID.randomUUID().toString()
 
         val specification = Specification(
-            uuid,
+            ServiceId(uuid),
             "Test",
             "Description",
             listOf(Version(SWAGGER_SPECIFICATION, metadata)),
@@ -132,7 +133,7 @@ internal class SpecificationControllerUnitTest {
         given(specificationPersistenceService.findAll()).willReturn(
             arrayListOf(
                 Specification(
-                    uuid,
+                    ServiceId(uuid),
                     "Test",
                     "Description",
                     listOf(Version(SWAGGER_SPECIFICATION, metadata)),

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerUnitTest.kt
@@ -1,20 +1,20 @@
 package com.tngtech.apicenter.backend.connector.rest.controller
 
-import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationDto
-import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileDto
-import com.tngtech.apicenter.backend.connector.rest.mapper.SpecificationDtoMapper
-import com.tngtech.apicenter.backend.connector.rest.service.SynchronizationService
-import com.tngtech.apicenter.backend.domain.entity.Specification
-import com.tngtech.apicenter.backend.domain.entity.Version
 import com.nhaarman.mockitokotlin2.given
 import com.nhaarman.mockitokotlin2.mock
+import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationDto
+import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileDto
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationMetaData
 import com.tngtech.apicenter.backend.connector.rest.dto.VersionDto
+import com.tngtech.apicenter.backend.connector.rest.mapper.SpecificationDtoMapper
+import com.tngtech.apicenter.backend.connector.rest.service.SynchronizationService
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
+import com.tngtech.apicenter.backend.domain.entity.Specification
+import com.tngtech.apicenter.backend.domain.entity.Version
 import com.tngtech.apicenter.backend.domain.service.SpecificationPersistenceService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import java.util.UUID
+import java.util.*
 
 internal class SpecificationControllerUnitTest {
 
@@ -44,14 +44,14 @@ internal class SpecificationControllerUnitTest {
             SpecificationFileDto(SWAGGER_SPECIFICATION)
 
         val specification = Specification(
-            UUID.fromString(UUID_STRING),
+            UUID_STRING,
             "Swagger Petstore",
             "Description",
             listOf(Version(SWAGGER_SPECIFICATION, metadata)),
             null
         )
         val specificationDto = SpecificationDto(
-            UUID.fromString(UUID_STRING),
+            UUID_STRING,
             "Swagger Petstore",
             "Description",
             listOf(VersionDto(SWAGGER_SPECIFICATION, metadata)),
@@ -73,17 +73,17 @@ internal class SpecificationControllerUnitTest {
                 SWAGGER_SPECIFICATION,
                 null,
                 null,
-                UUID.fromString(UUID_STRING)
+                UUID_STRING
             )
         val specification = Specification(
-            UUID.fromString(UUID_STRING),
+            UUID_STRING,
             "Swagger Petstore",
             "Description",
             listOf(Version(SWAGGER_SPECIFICATION, metadata)),
             null
         )
         val specificationDto = SpecificationDto(
-            UUID.fromString(UUID_STRING),
+            UUID_STRING,
             "Swagger Petstore",
             "Description",
             listOf(VersionDto(SWAGGER_SPECIFICATION, metadata)),
@@ -99,7 +99,7 @@ internal class SpecificationControllerUnitTest {
 
         assertThat(returnedSpecificationDto).isEqualTo(
             SpecificationDto(
-                UUID.fromString(UUID_STRING),
+                UUID_STRING,
                 "Swagger Petstore",
                 "Description",
                 listOf(VersionDto(SWAGGER_SPECIFICATION, metadata)),
@@ -110,7 +110,7 @@ internal class SpecificationControllerUnitTest {
 
     @Test
     fun findAllSpecifications_shouldReturnSpecifications() {
-        val uuid = UUID.randomUUID()
+        val uuid = UUID.randomUUID().toString()
 
         val specification = Specification(
             uuid,

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionControllerUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionControllerUnitTest.kt
@@ -7,6 +7,7 @@ import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationMetaData
 import com.tngtech.apicenter.backend.connector.rest.dto.VersionDto
 import com.tngtech.apicenter.backend.connector.rest.mapper.VersionDtoMapper
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
+import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Version
 import com.tngtech.apicenter.backend.domain.service.VersionPersistenceService
 import org.assertj.core.api.Assertions.assertThat
@@ -30,7 +31,7 @@ internal class VersionControllerUnitTest {
 
     @Test
     fun findOne_shouldReturnVersionDto() {
-        given(versionPersistenceService.findOne(specificationId, "1.0")).willReturn(version)
+        given(versionPersistenceService.findOne(ServiceId(specificationId), "1.0")).willReturn(version)
         given(versionDtoMapper.fromDomain(version)).willReturn(versionDto)
 
         assertThat(versionController.findVersion(specificationId, "1.0")).isEqualTo(versionDto)
@@ -40,7 +41,7 @@ internal class VersionControllerUnitTest {
     fun delete_shouldDeleteVersion() {
         versionController.deleteVersion(specificationId, "1.0")
 
-        verify(versionPersistenceService).delete(specificationId, "1.0")
+        verify(versionPersistenceService).delete(ServiceId(specificationId), "1.0")
     }
 
 }

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionControllerUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/VersionControllerUnitTest.kt
@@ -11,7 +11,6 @@ import com.tngtech.apicenter.backend.domain.entity.Version
 import com.tngtech.apicenter.backend.domain.service.VersionPersistenceService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import java.util.UUID
 
 internal class VersionControllerUnitTest {
 
@@ -21,7 +20,7 @@ internal class VersionControllerUnitTest {
 
     private val versionController = VersionController(versionPersistenceService, versionDtoMapper)
 
-    private val specificationId = UUID.fromString("7de07d27-eedb-4290-881a-6a402a81dd0f")
+    private val specificationId = "7de07d27-eedb-4290-881a-6a402a81dd0f"
 
     private val metadata = SpecificationMetaData("Swagger Petstore", "1.0.0", "Description", ApiLanguage.OPENAPI, null)
 

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationConverterTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationConverterTest.kt
@@ -39,9 +39,9 @@ class SpecificationConverterTest {
         given(specificationDataService.parseFileContent(SWAGGER_SPECIFICATION)).willReturn(
             SWAGGER_SPECIFICATION
         )
-        given(specificationDataService.readTitle(SWAGGER_SPECIFICATION)).willReturn("Swagger Petstore")
-        given(specificationDataService.readVersion(SWAGGER_SPECIFICATION)).willReturn("1.0.0")
-        given(specificationDataService.readDescription(SWAGGER_SPECIFICATION)).willReturn("Description")
+        given(specificationDataService.extractTitle(SWAGGER_SPECIFICATION)).willReturn("Swagger Petstore")
+        given(specificationDataService.extractVersion(SWAGGER_SPECIFICATION)).willReturn("1.0.0")
+        given(specificationDataService.extractDescription(SWAGGER_SPECIFICATION)).willReturn("Description")
 
         val specification = specificationConverter.convert(specificationFileDto, null, null)
 
@@ -71,9 +71,9 @@ class SpecificationConverterTest {
         given(specificationDataService.parseFileContent(SWAGGER_SPECIFICATION)).willReturn(
             SWAGGER_SPECIFICATION
         )
-        given(specificationDataService.readTitle(SWAGGER_SPECIFICATION)).willReturn("Swagger Petstore")
-        given(specificationDataService.readVersion(SWAGGER_SPECIFICATION)).willReturn("1.0.0")
-        given(specificationDataService.readDescription(SWAGGER_SPECIFICATION)).willReturn("Description")
+        given(specificationDataService.extractTitle(SWAGGER_SPECIFICATION)).willReturn("Swagger Petstore")
+        given(specificationDataService.extractVersion(SWAGGER_SPECIFICATION)).willReturn("1.0.0")
+        given(specificationDataService.extractDescription(SWAGGER_SPECIFICATION)).willReturn("Description")
 
         val specification = specificationConverter.convert(specificationFileDto, null, null)
 

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationFileDtoConverterTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationFileDtoConverterTest.kt
@@ -12,7 +12,7 @@ import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
-class SpecificationConverterTest {
+class SpecificationFileDtoConverterTest {
 
     companion object {
         const val SWAGGER_SPECIFICATION =
@@ -26,8 +26,8 @@ class SpecificationConverterTest {
 
     private val specificationFileService: SpecificationFileService = mock()
 
-    private val specificationConverter: SpecificationConverter =
-        SpecificationConverter(
+    private val specificationFileDtoConverter: SpecificationFileDtoConverter =
+        SpecificationFileDtoConverter(
             specificationFileService,
             specificationDataService
         )
@@ -43,7 +43,7 @@ class SpecificationConverterTest {
         given(specificationDataService.extractVersion(SWAGGER_SPECIFICATION)).willReturn("1.0.0")
         given(specificationDataService.extractDescription(SWAGGER_SPECIFICATION)).willReturn("Description")
 
-        val specification = specificationConverter.convert(specificationFileDto, null, null)
+        val specification = specificationFileDtoConverter.convert(specificationFileDto, null, null)
 
         val expectedSpecification = Specification(
             specification.id,
@@ -75,7 +75,7 @@ class SpecificationConverterTest {
         given(specificationDataService.extractVersion(SWAGGER_SPECIFICATION)).willReturn("1.0.0")
         given(specificationDataService.extractDescription(SWAGGER_SPECIFICATION)).willReturn("Description")
 
-        val specification = specificationConverter.convert(specificationFileDto, null, null)
+        val specification = specificationFileDtoConverter.convert(specificationFileDto, null, null)
 
         val expectedSpecification = Specification(
             specification.id,

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataServiceTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataServiceTest.kt
@@ -38,36 +38,36 @@ class SpecificationDataServiceTest {
 
     @Test
     fun readTitle_shouldReturnTitle() {
-        assertThat(specificationDataService.readTitle(SWAGGER_SPECIFICATION)).isEqualTo("Swagger Petstore")
+        assertThat(specificationDataService.extractTitle(SWAGGER_SPECIFICATION)).isEqualTo("Swagger Petstore")
     }
 
     @Test
     fun readVersion_shouldReturnVersion() {
-        assertThat(specificationDataService.readVersion(SWAGGER_SPECIFICATION)).isEqualTo("1.0.0")
+        assertThat(specificationDataService.extractVersion(SWAGGER_SPECIFICATION)).isEqualTo("1.0.0")
     }
 
     @Test
     fun readDescription_shouldReturnDescription() {
-        assertThat(specificationDataService.readDescription(SWAGGER_SPECIFICATION)).isEqualTo("My Description")
+        assertThat(specificationDataService.extractDescription(SWAGGER_SPECIFICATION)).isEqualTo("My Description")
     }
 
     @Test
     fun readTitle_shouldFailWhenNoTitleIsGiven() {
-        assertThatThrownBy { specificationDataService.readTitle(SWAGGER_SPECIFICATION_WITHOUT_TITLE) }.isInstanceOf(
+        assertThatThrownBy { specificationDataService.extractTitle(SWAGGER_SPECIFICATION_WITHOUT_TITLE) }.isInstanceOf(
             SpecificationParseException::class.java
         )
     }
 
     @Test
     fun readVersion_shouldFailWhenNoVersionIsGiven() {
-        assertThatThrownBy { specificationDataService.readVersion(SWAGGER_SPECIFICATION_WITHOUT_VERSION) }.isInstanceOf(
+        assertThatThrownBy { specificationDataService.extractVersion(SWAGGER_SPECIFICATION_WITHOUT_VERSION) }.isInstanceOf(
             SpecificationParseException::class.java
         )
     }
 
     @Test
     fun readDescription_shouldReturnNullWhenNoDescriptionIsGiven() {
-        assertThat(specificationDataService.readDescription(SWAGGER_SPECIFICATION_WITHOUT_DESCRIPTION)).isNull()
+        assertThat(specificationDataService.extractDescription(SWAGGER_SPECIFICATION_WITHOUT_DESCRIPTION)).isNull()
     }
 
     @Test

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SynchronizationServiceTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SynchronizationServiceTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationMetaData
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
+import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Specification
 import com.tngtech.apicenter.backend.domain.entity.Version
 import com.tngtech.apicenter.backend.domain.service.SpecificationPersistenceService
@@ -36,30 +37,30 @@ class SynchronizationServiceTest {
     @Test
     fun synchronize_shouldStoreAdaptedSpecification() {
         val specification = Specification(
-            SPECIFICATION_ID,
+            ServiceId(SPECIFICATION_ID),
             "Swagger Petstore",
             "Description",
             listOf(Version(SWAGGER_SPECIFICATION, metadata)),
             REMOTE_ADDRESS
         )
         val updatedSpecification = Specification(
-            SPECIFICATION_ID,
+            ServiceId(SPECIFICATION_ID),
             "Swagger Petstore 2",
             "Description",
             listOf(Version(SWAGGER_SPECIFICATION, metadata)),
             REMOTE_ADDRESS
         )
 
-        given(specificationPersistenceService.findOne(SPECIFICATION_ID)).willReturn(specification)
+        given(specificationPersistenceService.findOne(ServiceId(SPECIFICATION_ID))).willReturn(specification)
         given(specificationFileService.retrieveFile(REMOTE_ADDRESS)).willReturn(UPDATED_SWAGGER_SPECIFICATION)
         given(specificationDataService.parseFileContent(UPDATED_SWAGGER_SPECIFICATION)).willReturn(
             UPDATED_SWAGGER_SPECIFICATION
         )
-        given(specificationDataService.readTitle(UPDATED_SWAGGER_SPECIFICATION)).willReturn("Swagger Petstore 2")
-        given(specificationDataService.readVersion(UPDATED_SWAGGER_SPECIFICATION)).willReturn("1.0.0")
-        given(specificationDataService.readDescription(UPDATED_SWAGGER_SPECIFICATION)).willReturn("Description")
+        given(specificationDataService.extractTitle(UPDATED_SWAGGER_SPECIFICATION)).willReturn("Swagger Petstore 2")
+        given(specificationDataService.extractVersion(UPDATED_SWAGGER_SPECIFICATION)).willReturn("1.0.0")
+        given(specificationDataService.extractDescription(UPDATED_SWAGGER_SPECIFICATION)).willReturn("Description")
 
-        synchronizationService.synchronize(SPECIFICATION_ID)
+        synchronizationService.synchronize(ServiceId(SPECIFICATION_ID))
 
         verify(specificationPersistenceService).save(updatedSpecification)
     }

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SynchronizationServiceTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SynchronizationServiceTest.kt
@@ -9,7 +9,6 @@ import com.tngtech.apicenter.backend.domain.entity.Specification
 import com.tngtech.apicenter.backend.domain.entity.Version
 import com.tngtech.apicenter.backend.domain.service.SpecificationPersistenceService
 import org.junit.Test
-import java.util.UUID
 
 class SynchronizationServiceTest {
 
@@ -37,21 +36,21 @@ class SynchronizationServiceTest {
     @Test
     fun synchronize_shouldStoreAdaptedSpecification() {
         val specification = Specification(
-            UUID.fromString(SPECIFICATION_ID),
+            SPECIFICATION_ID,
             "Swagger Petstore",
             "Description",
             listOf(Version(SWAGGER_SPECIFICATION, metadata)),
             REMOTE_ADDRESS
         )
         val updatedSpecification = Specification(
-            UUID.fromString(SPECIFICATION_ID),
+            SPECIFICATION_ID,
             "Swagger Petstore 2",
             "Description",
             listOf(Version(SWAGGER_SPECIFICATION, metadata)),
             REMOTE_ADDRESS
         )
 
-        given(specificationPersistenceService.findOne(UUID.fromString(SPECIFICATION_ID))).willReturn(specification)
+        given(specificationPersistenceService.findOne(SPECIFICATION_ID)).willReturn(specification)
         given(specificationFileService.retrieveFile(REMOTE_ADDRESS)).willReturn(UPDATED_SWAGGER_SPECIFICATION)
         given(specificationDataService.parseFileContent(UPDATED_SWAGGER_SPECIFICATION)).willReturn(
             UPDATED_SWAGGER_SPECIFICATION
@@ -60,7 +59,7 @@ class SynchronizationServiceTest {
         given(specificationDataService.readVersion(UPDATED_SWAGGER_SPECIFICATION)).willReturn("1.0.0")
         given(specificationDataService.readDescription(UPDATED_SWAGGER_SPECIFICATION)).willReturn("Description")
 
-        synchronizationService.synchronize(UUID.fromString(SPECIFICATION_ID))
+        synchronizationService.synchronize(SPECIFICATION_ID)
 
         verify(specificationPersistenceService).save(updatedSpecification)
     }

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/service/SpecificationDatabaseServiceUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/service/SpecificationDatabaseServiceUnitTest.kt
@@ -10,6 +10,7 @@ import com.tngtech.apicenter.backend.connector.database.repository.Specification
 import com.tngtech.apicenter.backend.connector.database.service.SpecificationDatabaseService
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationMetaData
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
+import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Specification
 import com.tngtech.apicenter.backend.domain.entity.Version
 import org.assertj.core.api.Assertions.assertThat
@@ -37,7 +38,7 @@ internal class SpecificationDatabaseServiceUnitTest {
     @Test
     fun save_shouldSaveObjects() {
         val specification = Specification(
-            "e33dc111-3dd6-40f4-9c54-a64f6b10ab49",
+            ServiceId("e33dc111-3dd6-40f4-9c54-a64f6b10ab49"),
             "Spec",
             "Description",
             listOf(Version("{\"json\": \"true\"}", SpecificationMetaData("Spec", "1.0.0", "Description", ApiLanguage.OPENAPI, null))),
@@ -66,20 +67,20 @@ internal class SpecificationDatabaseServiceUnitTest {
 
     @Test
     fun delete_shouldDeleteObject() {
-        val uuid = UUID.randomUUID().toString()
+        val uuid = ServiceId(UUID.randomUUID().toString())
 
         specificationDatabaseService.delete(uuid)
-        verify(specificationRepository).deleteById(uuid)
+        verify(specificationRepository).deleteById(uuid.id)
     }
 
     @Test
     fun exists_shouldCheckForExistence() {
-        val uuid = "e33dc111-3dd6-40f4-9c54-a64f6b10ab49"
+        val uuid = ServiceId("e33dc111-3dd6-40f4-9c54-a64f6b10ab49")
 
-        given(specificationRepository.existsById(uuid)).willReturn(true)
+        given(specificationRepository.existsById(uuid.id)).willReturn(true)
 
         assertThat(specificationDatabaseService.exists(uuid)).isTrue()
 
-        verify(specificationRepository).existsById(uuid)
+        verify(specificationRepository).existsById(uuid.id)
     }
 }

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/service/SpecificationDatabaseServiceUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/service/SpecificationDatabaseServiceUnitTest.kt
@@ -1,23 +1,23 @@
 package com.tngtech.apicenter.backend.connector.service
 
 import com.nhaarman.mockitokotlin2.given
-import com.tngtech.apicenter.backend.connector.database.entity.SpecificationEntity
-import com.tngtech.apicenter.backend.connector.database.repository.SpecificationRepository
-import com.tngtech.apicenter.backend.connector.database.service.SpecificationDatabaseService
-import com.tngtech.apicenter.backend.domain.entity.Specification
-import com.tngtech.apicenter.backend.domain.entity.Version
 import com.nhaarman.mockitokotlin2.mock
+import com.tngtech.apicenter.backend.connector.database.entity.SpecificationEntity
 import com.tngtech.apicenter.backend.connector.database.entity.VersionEntity
 import com.tngtech.apicenter.backend.connector.database.entity.VersionId
 import com.tngtech.apicenter.backend.connector.database.mapper.SpecificationEntityMapper
+import com.tngtech.apicenter.backend.connector.database.repository.SpecificationRepository
+import com.tngtech.apicenter.backend.connector.database.service.SpecificationDatabaseService
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationMetaData
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
+import com.tngtech.apicenter.backend.domain.entity.Specification
+import com.tngtech.apicenter.backend.domain.entity.Version
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnitRunner
-import java.util.UUID
+import java.util.*
 import javax.persistence.EntityManager
 
 @RunWith(MockitoJUnitRunner::class)
@@ -37,7 +37,7 @@ internal class SpecificationDatabaseServiceUnitTest {
     @Test
     fun save_shouldSaveObjects() {
         val specification = Specification(
-            UUID.fromString("e33dc111-3dd6-40f4-9c54-a64f6b10ab49"),
+            "e33dc111-3dd6-40f4-9c54-a64f6b10ab49",
             "Spec",
             "Description",
             listOf(Version("{\"json\": \"true\"}", SpecificationMetaData("Spec", "1.0.0", "Description", ApiLanguage.OPENAPI, null))),
@@ -45,7 +45,7 @@ internal class SpecificationDatabaseServiceUnitTest {
         )
 
         val specificationEntity = SpecificationEntity(
-            UUID.fromString("e33dc111-3dd6-40f4-9c54-a64f6b10ab49"),
+            "e33dc111-3dd6-40f4-9c54-a64f6b10ab49",
             "Spec",
             "Description",
             listOf(VersionEntity(VersionId(null, "1.0.0"), "{\"json\": \"true\"}", "Spec", "Description", ApiLanguage.OPENAPI, "", null, null)),
@@ -66,7 +66,7 @@ internal class SpecificationDatabaseServiceUnitTest {
 
     @Test
     fun delete_shouldDeleteObject() {
-        val uuid = UUID.randomUUID()
+        val uuid = UUID.randomUUID().toString()
 
         specificationDatabaseService.delete(uuid)
         verify(specificationRepository).deleteById(uuid)
@@ -74,7 +74,7 @@ internal class SpecificationDatabaseServiceUnitTest {
 
     @Test
     fun exists_shouldCheckForExistence() {
-        val uuid = UUID.fromString("e33dc111-3dd6-40f4-9c54-a64f6b10ab49")
+        val uuid = "e33dc111-3dd6-40f4-9c54-a64f6b10ab49"
 
         given(specificationRepository.existsById(uuid)).willReturn(true)
 


### PR DESCRIPTION
Groups specifications by ID instead of by title.

Either the ID is a field in the specification file DTO when the specification is uploaded, or in the specification body under `info/x-api-id`. Non-OpenAPI formatted specifications (eg. GraphQL) will only be able to use the former. If there is a mismatch between the ID in the upload content and the ID in the URL used for the upload request, the upload is rejected.

To allow for arbitrary user defined IDs, changes the ID type within ApiCenter from a UUID, to a class which wraps a String. Because JPA only allows primitive Java types as @Id fields, this is still a String, with the wrapping / unwrapping occurring when the data is stored / retrieved.

IDs are restricted to alphanumeric strings with hyphens and underscores, validation occurs in the wrapper class constructor. This may be unnecessarily restrictive, but without any check, a specification with eg. `x-api-id: unique/identifier` can be uploaded, but never viewed or deleted. Clicking on the links within the web interface will involve a different string literal (`http://localhost:4200/specifications/unique%2Fidentifier/0.1.8`)

Some of the columns of type String in the integration test database population file were in the wrong order, however this has only just now become apparent with the addition of the tests in this PR.

Also runs IntelliJ's "Optimise Imports" (to get rid of the `java.util.UUID` references), hence those diffs.

Closes #16 
 