### PR TITLE
Fix for integer IDs

### DIFF
--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
@@ -8,6 +8,7 @@ import com.tngtech.apicenter.backend.domain.exceptions.SpecificationParseExcepti
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import java.io.IOException
+import java.lang.ClassCastException
 
 @Service
 class SpecificationDataService @Autowired constructor(
@@ -74,6 +75,8 @@ class SpecificationDataService @Autowired constructor(
     fun extractId(json: String): String? =
         try {
             JsonPath.read<String>(json, "$.info.x-api-id")
+        } catch (exception: ClassCastException) {
+            JsonPath.read<Integer>(json, "$.info.x-api-id").toString()
         } catch (exception: PathNotFoundException) {
             null
         }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
@@ -72,12 +72,18 @@ class SpecificationDataService @Autowired constructor(
             null
         }
 
-    fun extractId(json: String): String? =
-        try {
-            JsonPath.read<String>(json, "$.info.x-api-id")
+    fun extractId(json: String): String? {
+        val idPath = "$.info.x-api-id"
+        return try {
+            JsonPath.read<String>(json, idPath)
         } catch (exception: ClassCastException) {
-            JsonPath.read<Integer>(json, "$.info.x-api-id").toString()
+            try {
+                JsonPath.read<Integer>(json, idPath).toString()
+            } catch (exception: ClassCastException) {
+                JsonPath.read<Double>(json, idPath).toString()
+            }
         } catch (exception: PathNotFoundException) {
             null
         }
+    }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
@@ -8,7 +8,6 @@ import com.tngtech.apicenter.backend.domain.exceptions.SpecificationParseExcepti
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import java.io.IOException
-import java.lang.ClassCastException
 
 @Service
 class SpecificationDataService @Autowired constructor(
@@ -73,17 +72,8 @@ class SpecificationDataService @Autowired constructor(
         }
 
     fun extractId(json: String): String? {
-        val idPath = "$.info.x-api-id"
-        return try {
-            JsonPath.read<String>(json, idPath)
-        } catch (exception: ClassCastException) {
-            try {
-                JsonPath.read<Int>(json, idPath).toString()
-            } catch (exception: ClassCastException) {
-                JsonPath.read<Double>(json, idPath).toString()
-            }
-        } catch (exception: PathNotFoundException) {
-            null
-        }
+        val parsedJson = objectMapper.readTree(json)
+        val jsonNode = parsedJson.at("/info/x-api-id")
+        return if (jsonNode.isMissingNode) null else jsonNode.asText()
     }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
@@ -74,6 +74,10 @@ class SpecificationDataService @Autowired constructor(
     fun extractId(json: String): String? {
         val parsedJson = objectMapper.readTree(json)
         val jsonNode = parsedJson.at("/info/x-api-id")
-        return if (jsonNode.isMissingNode) null else jsonNode.asText()
+        return if (jsonNode.isMissingNode) {
+            null
+        } else {
+            jsonNode.asText()
+        }
     }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataService.kt
@@ -78,7 +78,7 @@ class SpecificationDataService @Autowired constructor(
             JsonPath.read<String>(json, idPath)
         } catch (exception: ClassCastException) {
             try {
-                JsonPath.read<Integer>(json, idPath).toString()
+                JsonPath.read<Int>(json, idPath).toString()
             } catch (exception: ClassCastException) {
                 JsonPath.read<Double>(json, idPath).toString()
             }


### PR DESCRIPTION
A bug noticed when attempting to set an `x-api-id` as an integer, the application threw an uncaught exception and the file upload failed. Now the specification upload works as expected.