### PR TITLE
Redirect to requested resource after login

### DIFF
--- a/frontend/src/app/auth/auth.guard.ts
+++ b/frontend/src/app/auth/auth.guard.ts
@@ -12,7 +12,7 @@ export class AuthenticationGuard implements CanActivate {
       return true;
     }
 
-    this.router.navigate(['/login']);
+    this.router.navigate(['/login'], {queryParams: {redirectUrl: state.url}});
     return false;
   }
 

--- a/frontend/src/app/login/login.component.ts
+++ b/frontend/src/app/login/login.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {SessionService} from '../session.service';
-import {Router} from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
 import {SessionToken} from '../models/sessiontoken';
 import {LoginEvent} from '../login.event';
 
@@ -14,12 +14,15 @@ export class LoginComponent implements OnInit {
   loginForm: FormGroup;
   submitted = false;
   loginError = false;
+  redirectUrl: string;
 
   constructor(private formBuilder: FormBuilder, private sessionService: SessionService, private router: Router,
-              private loginEvent: LoginEvent) {
+              private loginEvent: LoginEvent, private route: ActivatedRoute) {
   }
 
   ngOnInit() {
+    this.redirectUrl = this.route.snapshot.queryParamMap.get('redirectUrl');
+
     this.loginForm = this.formBuilder.group({
       username: ['', Validators.required],
       password: ['', Validators.required]
@@ -36,7 +39,7 @@ export class LoginComponent implements OnInit {
           localStorage.setItem('username', data.username);
 
           this.loginEvent.changeValue(data);
-          this.router.navigate(['/']);
+          this.router.navigate([this.redirectUrl || '/']);
         }
 
         return data;


### PR DESCRIPTION
Previously, if an unauthenticated user requested a resource, they were redirected to `/login`, and after a successful login, were always redirected to `/`.

This change saves the initially requested URL, and redirects there after login.