### PR TITLE
Compare JWT subject in frontend authentication

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11248,6 +11248,11 @@
         }
       }
     },
+    "jwt-decode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+    },
     "karma": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/karma/-/karma-2.0.0.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "graphql-tools": "^4.0.4",
     "invariant": "^2.2.4",
     "jquery": "^3.3.1",
+    "jwt-decode": "^2.2.0",
     "ngx-markdown": "^7.1.3",
     "npm": "^6.0.1",
     "open-iconic": "^1.1.1",

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -17,7 +17,8 @@ import {HighlightSearchResultPipe} from './pipes/highlight-search-result.pipe';
 import {TrimSearchResultPipe} from './pipes/trim-search-result.pipe';
 import {FormatSearchResultPipe} from './pipes/format-search-result.pipe';
 import { LoginComponent } from './login/login.component';
-import {AuthenticationGuard} from './guards/authentication.guard';
+import {AuthenticationGuard} from './auth/auth.guard';
+import {AuthenticationService} from './auth/auth.service';
 import {TokenInterceptor} from './interceptors/token.interceptor';
 import {LoginEvent} from './login.event';
 import {MarkdownModule} from 'ngx-markdown';
@@ -64,6 +65,7 @@ const appRoutes: Routes = [
   ],
   providers: [
     AuthenticationGuard,
+    AuthenticationService,
     { provide: HTTP_INTERCEPTORS, useClass: TokenInterceptor, multi: true },
     LoginEvent
   ],

--- a/frontend/src/app/auth/auth.guard.ts
+++ b/frontend/src/app/auth/auth.guard.ts
@@ -1,13 +1,14 @@
 import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot} from '@angular/router';
 import {Injectable} from '@angular/core';
+import { AuthenticationService } from './auth.service';
 
 @Injectable()
 export class AuthenticationGuard implements CanActivate {
 
-  constructor(private router: Router) { }
+  constructor(private router: Router, private auth: AuthenticationService) { }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-    if (localStorage.getItem('token')) {
+    if (this.auth.isTokenValid()) {
       return true;
     }
 

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import * as jwt_decode from 'jwt-decode';
+
+@Injectable()
+export class AuthenticationService {
+
+  getToken(): string {
+    return localStorage.getItem('token');
+  }
+
+  getUsername(): string {
+    return localStorage.getItem('username');
+  }
+
+  isTokenValid(token?: string): boolean {
+    if (!token) {
+      token = this.getToken();
+    }
+
+    if (!token) {
+      return false;
+    }
+
+    try {
+      const decoded = jwt_decode(token);
+      return decoded.sub === this.getUsername();
+    } catch (exception) {
+      // jwt-decode throws InvalidTokenError if token incorrectly formatted
+      return false;
+    }
+  }
+}

--- a/frontend/src/app/specification-overview/specification-overview.component.ts
+++ b/frontend/src/app/specification-overview/specification-overview.component.ts
@@ -117,6 +117,13 @@ export class SpecificationOverviewComponent implements OnInit {
   }
 
   private async getSpecifications() {
-    this.specificationService.getSpecifications().subscribe((data: Specification[]) => this.specifications = data);
+    this.specificationService.getSpecifications().subscribe(
+     (data: Specification[]) => this.specifications = data,
+     error1 => {
+       if (error1.status === 403) {
+         this.error = 'You don\'t have permission to access content on this page';
+       }
+     }
+   );
   }
 }


### PR DESCRIPTION
Previously, the only check that Angular's authentication guard provided was that the string in `window.localStorage.token` was not null.

If a user sets the token to any random string (with the browser console), they bypass the guard, and can get to `/`. No specifications appear in the table, because the backend will reject the 'token' and so respond with Spring's 403 default response. However no error message is displayed; it simply looks as though no specifications have ever been uploaded.

This PR makes the guard _slightly_ more sophisticated. It decodes the current token, and checks the token's subject matches the username in local storage. Failure will redirect to `/login` again.

We cannot, client-side, verify that the token is signed correctly, because the HMAC secret stays server-side. If a user forges a token on [jwt.io](https://jwt.io/), they can get around the frontend guard. (This is equivalent to -- before the changes in this PR -- setting the token to a random string, as described above.)

<img width="409" alt="jwt-io" src="https://user-images.githubusercontent.com/6897716/55537251-12289280-56bc-11e9-87a9-6914dc636114.PNG">

<img width="855" alt="console" src="https://user-images.githubusercontent.com/6897716/55537286-23719f00-56bc-11e9-83bc-d76e4ece32ae.PNG">

However now there is an error displayed when the homepage receives a 403 response from the backend.

<img width="425" alt="permission-error" src="https://user-images.githubusercontent.com/6897716/55537283-210f4500-56bc-11e9-86fc-684e580344d1.PNG">
