### PR TITLE
Replace usage of HttpClient outside of Service

### DIFF
--- a/frontend/src/app/specification-store.service.ts
+++ b/frontend/src/app/specification-store.service.ts
@@ -13,17 +13,17 @@ export class SpecificationStore {
 
   public getYamlSpecification(serviceId: string, version: string) {
     const headers = new HttpHeaders({'Accept': 'application/yml'});
-    return this.http.get<Specification>(this.urlRoot + '/' + serviceId + '/versions/' + version, {headers})
+    return this.http.get<Specification>(this.urlRoot + '/' + serviceId + '/version/' + version, {headers})
       .catch((error: any) => throwError(error || 'Server error'));
   }
 
   public getSpecification(serviceId: string, version: string) {
-    return this.http.get<Specification>(this.urlRoot + '/' + serviceId + '/versions/' + version)
+    return this.http.get<Specification>(this.urlRoot + '/' + serviceId + '/version/' + version)
       .catch((error: any) => throwError(error || 'Server error'));
   }
 
   public deleteSpecification(serviceId: string, version: string): Observable<Specification> {
-    return this.http.delete<Specification>(this.urlRoot + '/' + serviceId + '/versions/' + version)
+    return this.http.delete<Specification>(this.urlRoot + '/' + serviceId + '/version/' + version)
       .catch((error: any) => throwError(error || 'Server error'));
   }
 }

--- a/frontend/src/app/specification-version/graphiql-wrapper.component.ts
+++ b/frontend/src/app/specification-version/graphiql-wrapper.component.ts
@@ -10,7 +10,6 @@ import GraphiQL from 'graphiql';
 import fetch from 'isomorphic-fetch';
 import {GraphQLSchema} from 'graphql';
 import {ActivatedRoute} from '@angular/router';
-import {HttpClient} from '@angular/common/http';
 import {makeExecutableSchema} from 'graphql-tools';
 import {SpecificationViewComponent} from './specification-view.component';
 import {environment} from '../../environments/environment';
@@ -24,8 +23,8 @@ import {SpecificationStore} from '../specification-store.service';
 export class GraphiQLWrapperComponent extends SpecificationViewComponent implements AfterViewChecked {
   public graphiql: string;
 
-  constructor(route: ActivatedRoute, http: HttpClient, specificationStore: SpecificationStore) {
-    super(route, http, specificationStore);
+  constructor(route: ActivatedRoute, specificationStore: SpecificationStore) {
+    super(route, specificationStore);
     this.graphiql = uuid.v1();
   }
 

--- a/frontend/src/app/specification-version/graphiql-wrapper.component.ts
+++ b/frontend/src/app/specification-version/graphiql-wrapper.component.ts
@@ -1,8 +1,6 @@
 import {
   AfterViewChecked,
-  Component,
-  Input,
-  OnDestroy,
+  Component
 } from '@angular/core';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
@@ -15,8 +13,8 @@ import {ActivatedRoute} from '@angular/router';
 import {HttpClient} from '@angular/common/http';
 import {makeExecutableSchema} from 'graphql-tools';
 import {SpecificationViewComponent} from './specification-view.component';
-import {Specification} from '../models/specification';
 import {environment} from '../../environments/environment';
+import {SpecificationStore} from '../specification-store.service';
 
 @Component({
   selector: 'app-graphiql',
@@ -26,8 +24,8 @@ import {environment} from '../../environments/environment';
 export class GraphiQLWrapperComponent extends SpecificationViewComponent implements AfterViewChecked {
   public graphiql: string;
 
-  constructor(route: ActivatedRoute, http: HttpClient) {
-    super(route, http);
+  constructor(route: ActivatedRoute, http: HttpClient, specificationStore: SpecificationStore) {
+    super(route, http, specificationStore);
     this.graphiql = uuid.v1();
   }
 

--- a/frontend/src/app/specification-version/specification-view.component.ts
+++ b/frontend/src/app/specification-version/specification-view.component.ts
@@ -1,7 +1,6 @@
 import {Component, OnInit, Output} from '@angular/core';
 import {Specification} from '../models/specification';
 import {ActivatedRoute} from '@angular/router';
-import {HttpClient} from '@angular/common/http';
 import {SpecificationStore} from '../specification-store.service';
 
 @Component({
@@ -14,7 +13,7 @@ export class SpecificationViewComponent implements OnInit {
   @Output() specification: Specification;
   error: string;
 
-  constructor(protected route: ActivatedRoute, protected http: HttpClient, protected specificationStore: SpecificationStore) {
+  constructor(protected route: ActivatedRoute, protected specificationStore: SpecificationStore) {
   }
 
   ngOnInit() {

--- a/frontend/src/app/specification-version/specification-view.component.ts
+++ b/frontend/src/app/specification-version/specification-view.component.ts
@@ -18,7 +18,7 @@ export class SpecificationViewComponent implements OnInit {
 
   ngOnInit() {
     this.route.params.subscribe(params => {
-      this.specificationStore.getSpecification(params['specificationId'], params['version'])
+      this.specificationStore.getSpecification(params['serviceId'], params['version'])
         .subscribe(data => {
           this.specification = data;
         },

--- a/frontend/src/app/specification-version/specification-view.component.ts
+++ b/frontend/src/app/specification-version/specification-view.component.ts
@@ -1,32 +1,29 @@
 import {Component, OnInit, Output} from '@angular/core';
 import {Specification} from '../models/specification';
-import {environment} from '../../environments/environment';
 import {ActivatedRoute} from '@angular/router';
 import {HttpClient} from '@angular/common/http';
+import {SpecificationStore} from '../specification-store.service';
 
 @Component({
   selector: 'app-specification-view',
   templateUrl: './specification-view.component.html',
+  providers: [SpecificationStore]
 })
 
 export class SpecificationViewComponent implements OnInit {
   @Output() specification: Specification;
   error: string;
 
-  constructor(protected route: ActivatedRoute, protected http: HttpClient) {
+  constructor(protected route: ActivatedRoute, protected http: HttpClient, protected specificationStore: SpecificationStore) {
   }
 
   ngOnInit() {
     this.route.params.subscribe(params => {
-      this.http.get<Specification>(environment.apiUrl + '/service/' + params['serviceId'] + '/version/' + params['version'])
+      this.specificationStore.getSpecification(params['specificationId'], params['version'])
         .subscribe(data => {
           this.specification = data;
         },
-      err => {
-          if (err.status === 404) {
-            this.error = 'Specification not found';
-          }
-        });
+      error => this.error = error.error.userMessage);
     });
   }
 }

--- a/frontend/src/app/specification-version/swagger-ui-wrapper.component.ts
+++ b/frontend/src/app/specification-version/swagger-ui-wrapper.component.ts
@@ -4,6 +4,7 @@ import {HttpClient} from '@angular/common/http';
 import * as SwaggerUI from 'swagger-ui';
 import {Specification} from '../models/specification';
 import {SpecificationViewComponent} from './specification-view.component';
+import {SpecificationStore} from '../specification-store.service';
 
 @Component({
   selector: 'app-swagger-ui',
@@ -13,8 +14,8 @@ import {SpecificationViewComponent} from './specification-view.component';
 export class SwaggerUiWrapperComponent extends SpecificationViewComponent implements OnChanges {
   @Input() specification: Specification;
 
-  constructor(route: ActivatedRoute, http: HttpClient) {
-    super(route, http);
+  constructor(route: ActivatedRoute, http: HttpClient, specificationStore: SpecificationStore) {
+    super(route, http, specificationStore);
   }
 
   ngOnChanges() {

--- a/frontend/src/app/specification-version/swagger-ui-wrapper.component.ts
+++ b/frontend/src/app/specification-version/swagger-ui-wrapper.component.ts
@@ -1,6 +1,5 @@
 import {Component, Input, OnChanges} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
-import {HttpClient} from '@angular/common/http';
 import * as SwaggerUI from 'swagger-ui';
 import {Specification} from '../models/specification';
 import {SpecificationViewComponent} from './specification-view.component';
@@ -14,8 +13,8 @@ import {SpecificationStore} from '../specification-store.service';
 export class SwaggerUiWrapperComponent extends SpecificationViewComponent implements OnChanges {
   @Input() specification: Specification;
 
-  constructor(route: ActivatedRoute, http: HttpClient, specificationStore: SpecificationStore) {
-    super(route, http, specificationStore);
+  constructor(route: ActivatedRoute, specificationStore: SpecificationStore) {
+    super(route, specificationStore);
   }
 
   ngOnChanges() {


### PR DESCRIPTION
In the VersionView component there was a direct `HttpClient.get` call, which is supposed to be abstracted away by the VersionService.