### PR TITLE
Redo metadata fix

### DIFF
--- a/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerIntegrationTest.kt
+++ b/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerIntegrationTest.kt
@@ -79,6 +79,23 @@ internal class ServiceControllerIntegrationTest {
     }
 
     @Test
+    fun uploadSpecification_shouldCreateSpecificationWithMetadata() {
+        mockMvc.perform(
+                post("/api/v1/service")
+                        .with(user("user"))
+                        .with(csrf())
+                        .contentType("application/json")
+                        .content("""
+                           {"fileContent":"t","metadata":{"title":"My title","version":"v3","description":"","language":"GRAPHQL","endpointUrl":""}}
+                        """.trimIndent()
+                        )
+        )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.metadata.title", equalTo("My title")))
+                .andExpect(jsonPath("$.metadata.version", equalTo("v3")))
+    }
+
+    @Test
     fun uploadSpecification_shouldDetectVersionClash_identicalContent() {
         mockMvc.perform(
                 post("/api/v1/service")

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/mapper/converter/SpecificationEntityConverter.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/mapper/converter/SpecificationEntityConverter.kt
@@ -2,9 +2,9 @@ package com.tngtech.apicenter.backend.connector.database.mapper.converter
 
 import com.tngtech.apicenter.backend.connector.database.entity.SpecificationEntity
 import com.tngtech.apicenter.backend.connector.database.entity.SpecificationId
-import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationMetadata
 import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Specification
+import com.tngtech.apicenter.backend.domain.entity.SpecificationMetadata
 import ma.glasnost.orika.MappingContext
 import ma.glasnost.orika.converter.BidirectionalConverter
 import ma.glasnost.orika.metadata.Type

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationDto.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationDto.kt
@@ -1,5 +1,7 @@
 package com.tngtech.apicenter.backend.connector.rest.dto
 
+import com.tngtech.apicenter.backend.domain.entity.SpecificationMetadata
+
 data class SpecificationDto(
     val content: String,
     val metadata: SpecificationMetadata

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationFileDto.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationFileDto.kt
@@ -2,10 +2,8 @@ package com.tngtech.apicenter.backend.connector.rest.dto
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
-import com.tngtech.apicenter.backend.domain.entity.ServiceId
 
-data class SpecificationMetadata constructor(
-    val id: ServiceId,
+data class SpecificationFileMetadata constructor(
     val title: String,
     val version: String,
     val description: String?,
@@ -16,6 +14,6 @@ data class SpecificationMetadata constructor(
 data class SpecificationFileDto @JsonCreator constructor(
         val fileContent: String?,
         val fileUrl: String? = "",
-        val metadata: SpecificationMetadata? = null,
+        val metadata: SpecificationFileMetadata? = null,
         val id: String? = null
 )

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/configurer/SpecificationFileDtoMappingConfigurer.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/configurer/SpecificationFileDtoMappingConfigurer.kt
@@ -1,7 +1,6 @@
 package com.tngtech.apicenter.backend.connector.rest.mapper.configurer
 
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationDto
-import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileDto
 import com.tngtech.apicenter.backend.connector.rest.mapper.converter.SpecificationFileDtoConverter
 import com.tngtech.apicenter.backend.domain.entity.Specification
 import ma.glasnost.orika.MapperFactory
@@ -16,12 +15,6 @@ class SpecificationFileDtoMappingConfigurer constructor(private val specificatio
         orikaMapperFactory.converterFactory.registerConverter(specificationFileDtoConverter)
 
         orikaMapperFactory.classMap(Specification::class.java, SpecificationDto::class.java)
-            .field("metadata.id.id", "metadata.id")
-            .byDefault()
-            .register()
-
-        orikaMapperFactory.classMap(SpecificationFileDto::class.java, Specification::class.java)
-            .field("id", "metadata.id.id")
             .byDefault()
             .register()
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationFileDtoConverter.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationFileDtoConverter.kt
@@ -3,14 +3,11 @@ package com.tngtech.apicenter.backend.connector.rest.mapper.converter
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileDto
 import com.tngtech.apicenter.backend.connector.rest.service.SpecificationDataParser
 import com.tngtech.apicenter.backend.connector.rest.service.SpecificationFileDownloader
-import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Specification
-import com.tngtech.apicenter.backend.domain.exceptions.MismatchedServiceIdException
 import ma.glasnost.orika.CustomConverter
 import ma.glasnost.orika.MappingContext
 import ma.glasnost.orika.metadata.Type
 import org.springframework.stereotype.Component
-import java.util.*
 
 @Component
 class SpecificationFileDtoConverter constructor(
@@ -29,20 +26,12 @@ class SpecificationFileDtoConverter constructor(
         val parsedFileContent = if (specificationFileDto.metadata != null) fileContent
                                 else specificationDataParser.parseFileContent(fileContent)
 
-        val idFromUpload = specificationDataParser.extractId(parsedFileContent)
-        val idFromPath = specificationFileDto.id
-        val serviceId = getConsistentServiceId(idFromUpload, idFromPath)
-
-        val metadata = specificationFileDto.metadata ?:
-            specificationDataParser.makeSpecificationMetadata(parsedFileContent, serviceId, specificationFileDto.fileUrl)
+        val metadata = specificationDataParser.makeSpecificationMetadata(
+                parsedFileContent,
+                specificationFileDto.id,
+                specificationFileDto.metadata)
 
         return Specification(parsedFileContent, metadata)
     }
 
-    private fun getConsistentServiceId(idFromUpload: String?, idFromPath: String?): ServiceId {
-        if (idFromUpload != null && idFromPath != null && idFromUpload != idFromPath) {
-            throw MismatchedServiceIdException(idFromUpload, idFromPath)
-        }
-        return ServiceId(idFromUpload ?: idFromPath ?: UUID.randomUUID().toString())
-    }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/RemoteServiceUpdater.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/RemoteServiceUpdater.kt
@@ -22,7 +22,7 @@ class RemoteServiceUpdater constructor(
 
         val fileContent = specificationFileDownloader.retrieveFile(remoteAddress)
         val content = specificationDataParser.parseFileContent(fileContent)
-        val metadata = specificationDataParser.makeSpecificationMetadata(content, serviceId, remoteAddress)
+        val metadata = specificationDataParser.makeSpecificationMetadata(content, serviceId.id)
 
         val specification = Specification(content, metadata)
         serviceHandler.addNewSpecification(specification, serviceId, service.remoteAddress)

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Specification.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Specification.kt
@@ -1,5 +1,12 @@
 package com.tngtech.apicenter.backend.domain.entity
 
-import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationMetadata
+data class SpecificationMetadata constructor(
+    val id: ServiceId,
+    val title: String,
+    val version: String,
+    val description: String?,
+    val language: ApiLanguage,
+    val endpointUrl: String? = null
+)
 
 data class Specification(val content: String, val metadata: SpecificationMetadata)

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerUnitTest.kt
@@ -4,15 +4,11 @@ import com.nhaarman.mockitokotlin2.given
 import com.nhaarman.mockitokotlin2.mock
 import com.tngtech.apicenter.backend.connector.rest.dto.ServiceDto
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileDto
-import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationMetadata
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationDto
 import com.tngtech.apicenter.backend.connector.rest.mapper.ServiceDtoMapper
 import com.tngtech.apicenter.backend.connector.rest.mapper.SpecificationFileDtoMapper
 import com.tngtech.apicenter.backend.connector.rest.service.RemoteServiceUpdater
-import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
-import com.tngtech.apicenter.backend.domain.entity.ServiceId
-import com.tngtech.apicenter.backend.domain.entity.Service
-import com.tngtech.apicenter.backend.domain.entity.Specification
+import com.tngtech.apicenter.backend.domain.entity.*
 import com.tngtech.apicenter.backend.domain.handler.ServiceHandler
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerUnitTest.kt
@@ -3,12 +3,12 @@ package com.tngtech.apicenter.backend.connector.rest.controller
 import com.nhaarman.mockitokotlin2.given
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
-import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationMetadata
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationDto
 import com.tngtech.apicenter.backend.connector.rest.mapper.SpecificationFileDtoMapper
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
 import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Specification
+import com.tngtech.apicenter.backend.domain.entity.SpecificationMetadata
 import com.tngtech.apicenter.backend.domain.service.SpecificationPersistor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationFileDtoConverterTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationFileDtoConverterTest.kt
@@ -6,9 +6,10 @@ import com.tngtech.apicenter.backend.connector.rest.service.SpecificationFileDow
 import com.tngtech.apicenter.backend.domain.entity.Specification
 import com.nhaarman.mockitokotlin2.given
 import com.nhaarman.mockitokotlin2.mock
-import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationMetadata
+import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileMetadata
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
 import com.tngtech.apicenter.backend.domain.entity.ServiceId
+import com.tngtech.apicenter.backend.domain.entity.SpecificationMetadata
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -46,7 +47,7 @@ class SpecificationFileDtoConverterTest {
         val specificationFileDto = SpecificationFileDto(SWAGGER_SPECIFICATION, id = UUID_STRING)
 
         given(specificationFileDownloader.getLocalOrRemoteFileContent(specificationFileDto)).willReturn(SWAGGER_SPECIFICATION)
-        given(specificationDataParser.makeSpecificationMetadata(SWAGGER_SPECIFICATION, ServiceId(UUID_STRING), specificationFileDto.fileUrl)).willReturn(metadata)
+        given(specificationDataParser.makeSpecificationMetadata(SWAGGER_SPECIFICATION, UUID_STRING)).willReturn(metadata)
 
         val specification = specificationFileDtoConverter.convert(specificationFileDto, null, null)
 
@@ -66,7 +67,7 @@ class SpecificationFileDtoConverterTest {
         given(specificationFileDownloader.retrieveFile(SWAGGER_REMOTE)).willReturn(SWAGGER_SPECIFICATION)
         given(specificationFileDownloader.getLocalOrRemoteFileContent(specificationFileDto)).willReturn(SWAGGER_SPECIFICATION)
 
-        given(specificationDataParser.makeSpecificationMetadata(SWAGGER_SPECIFICATION, ServiceId(UUID_STRING), specificationFileDto.fileUrl)).willReturn(metadata)
+        given(specificationDataParser.makeSpecificationMetadata(fileContent = SWAGGER_SPECIFICATION, idFromPath = UUID_STRING)).willReturn(metadata)
 
         val specification = specificationFileDtoConverter.convert(specificationFileDto, null, null)
 

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/RemoteServiceUpdaterTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/RemoteServiceUpdaterTest.kt
@@ -3,11 +3,8 @@ package com.tngtech.apicenter.backend.connector.rest.service
 import com.nhaarman.mockitokotlin2.given
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
-import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationMetadata
-import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
-import com.tngtech.apicenter.backend.domain.entity.ServiceId
-import com.tngtech.apicenter.backend.domain.entity.Service
-import com.tngtech.apicenter.backend.domain.entity.Specification
+import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileMetadata
+import com.tngtech.apicenter.backend.domain.entity.*
 import com.tngtech.apicenter.backend.domain.handler.ServiceHandler
 import org.junit.Test
 
@@ -50,7 +47,10 @@ class RemoteServiceUpdaterTest {
         given(specificationDataParser.parseFileContent(UPDATED_SWAGGER_SPECIFICATION)).willReturn(
             UPDATED_SWAGGER_SPECIFICATION
         )
-        given(specificationDataParser.makeSpecificationMetadata(UPDATED_SWAGGER_SPECIFICATION, id, REMOTE_ADDRESS)).willReturn(metadata)
+        given(specificationDataParser.makeSpecificationMetadata(
+                fileContent = UPDATED_SWAGGER_SPECIFICATION,
+                idFromPath = SPECIFICATION_ID
+        )).willReturn(metadata)
 
         remoteServiceUpdater.synchronize(ServiceId(SPECIFICATION_ID))
 


### PR DESCRIPTION
The merge conflicts after the renaming were so complex, it was easier to rewrite the PR manually from master than to rebase.

No functionality has changed from the other PR.