### PR TITLE
Fix Heroku deploy

### DIFF
--- a/backend/src/main/resources/heroku.properties
+++ b/backend/src/main/resources/heroku.properties
@@ -2,3 +2,4 @@ jwt.secret=${JWT_SECRET}
 spring.datasource.url=${DATABASE_URL}
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.generate-ddl=true
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl

--- a/backend/src/main/resources/heroku.properties
+++ b/backend/src/main/resources/heroku.properties
@@ -3,3 +3,4 @@ spring.datasource.url=${DATABASE_URL}
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.generate-ddl=true
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+spring.flyway.baseline-on-migrate = true


### PR DESCRIPTION
Previously you could view and login to ApiCenter, but uploads would fail, returning from the backend an 500 Internal Server Error, root cause `org.postgresql.util.PSQLException: ERROR: column specificat1_.service_id does not exist`.

Assuming the column names in the code (in camelCase) were being converted inconsistently to snake_case, found a solution [here](https://stackoverflow.com/questions/25283198/spring-boot-jpa-column-name-annotation-ignored/38875123#38875123).