### PR TITLE
Small fixes to search functionality

### DIFF
--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
@@ -83,4 +83,7 @@ class ServiceController @Autowired constructor(
     @GetMapping("/search/{searchString}")
     fun searchForServices(@PathVariable searchString: String): List<ServiceDto> =
         serviceHandler.search(searchString).map { spec -> serviceDtoMapper.fromDomain(spec) }
+
+    @GetMapping("/search/")
+    fun searchWithBlank(): List<ServiceDto> = listOf()
 }

--- a/frontend/src/app/specification-search-detail/specification-search-detail.component.html
+++ b/frontend/src/app/specification-search-detail/specification-search-detail.component.html
@@ -10,7 +10,7 @@
         <div><p class="lead"><a [routerLink]="['/specifications', service.id, service.specifications[0].metadata.version]" routerLinkActive="active">{{ service.title }}</a></p></div>
         <div><p class="small"><markdown>{{ service.description != null && service.description.length > 100 ? (service.description | slice:0:100) + ' ...' : service.description }}</markdown></p></div>
       </div>
-      <div class="row top-buffer alert alert-danger" *ngIf="services.length == 0">
+      <div class="row top-buffer alert alert-danger" *ngIf="searchComplete && services.length == 0">
         No specifications found
       </div>
     </div>

--- a/frontend/src/app/specification-search-detail/specification-search-detail.component.html
+++ b/frontend/src/app/specification-search-detail/specification-search-detail.component.html
@@ -1,7 +1,7 @@
 <div class="container top-buffer">
   <div class="row">
     <div class="col">
-      <input type="search" class="form-control" placeholder="Search ..." (keyup)="searchSpecifications($event)" [(ngModel)]="searchString">
+      <input type="search" class="form-control" placeholder="Search..." (keyup)="searchServices($event)" [(ngModel)]="searchString">
     </div>
   </div>
   <div class="row top-buffer">

--- a/frontend/src/app/specification-search-detail/specification-search-detail.component.ts
+++ b/frontend/src/app/specification-search-detail/specification-search-detail.component.ts
@@ -29,7 +29,7 @@ export class SpecificationSearchDetailComponent implements OnInit {
   }
 
   public async searchServices(event) {
-    if (event.keyCode === 13 && this.searchString != "") {
+    if (event.keyCode === 13 && this.searchString !== undefined && this.searchString !== '') {
       this.serviceStore.searchForServices(this.searchString).subscribe((data: Service[]) => {
         this.services = data;
       });

--- a/frontend/src/app/specification-search-detail/specification-search-detail.component.ts
+++ b/frontend/src/app/specification-search-detail/specification-search-detail.component.ts
@@ -12,6 +12,7 @@ import {ActivatedRoute} from '@angular/router';
 export class SpecificationSearchDetailComponent implements OnInit {
   services: Service[];
   searchString: string;
+  searchComplete = false;
 
   constructor(private serviceStore: ServiceStore, private activatedRoute: ActivatedRoute) {
   }
@@ -19,14 +20,19 @@ export class SpecificationSearchDetailComponent implements OnInit {
   ngOnInit() {
     this.activatedRoute.params.subscribe(params => {
       this.serviceStore.searchForServices(params['searchString'])
-        .subscribe((data: Service[]) => this.services = data);
+        .subscribe((data: Service[]) => {
+          this.services = data;
+          this.searchComplete = true;
+        });
       this.searchString = params['searchString'];
     });
   }
 
   public async searchServices(event) {
-    if (event.keyCode === 13) {
-      this.serviceStore.searchForServices(this.searchString).subscribe((data: Service[]) => this.services = data);
+    if (event.keyCode === 13 && this.searchString != "") {
+      this.serviceStore.searchForServices(this.searchString).subscribe((data: Service[]) => {
+        this.services = data;
+      });
     }
   }
 

--- a/frontend/src/app/specification-search/specification-search.component.html
+++ b/frontend/src/app/specification-search/specification-search.component.html
@@ -1,1 +1,10 @@
-<input type="search" class="form-control" [(ngModel)]="searchString" placeholder="Search..." (keyup)="searchForString($event)">
+<input type="search"
+       class="form-control"
+       (keyup)="searchForString($event, searchHelp)"
+       ngbTooltip="Type a search term and press enter"
+       [autoClose]="'inside'"
+       triggers="manual"
+       #searchHelp="ngbTooltip"
+       placeholder="Search..."
+       [(ngModel)]="searchString"
+>

--- a/frontend/src/app/specification-search/specification-search.component.ts
+++ b/frontend/src/app/specification-search/specification-search.component.ts
@@ -17,12 +17,15 @@ export class SpecificationSearchComponent implements OnInit {
   ngOnInit() {
   }
 
-  public searchForString(event) {
-    if (event.keyCode === 13 && this.searchString !== undefined && this.searchString !== '') {
-      this.router.navigate(['search', this.searchString]);
-      this.searchString = '';
+  public searchForString(event, searchHelp) {
+    if (event.keyCode === 13) {
+      if (this.searchString !== undefined && this.searchString !== '') {
+        searchHelp.close();
+        this.router.navigate(['search', this.searchString]);
+        this.searchString = '';
+      } else {
+        searchHelp.open();
+      }
     }
   }
-
-
 }

--- a/frontend/src/app/specification-search/specification-search.component.ts
+++ b/frontend/src/app/specification-search/specification-search.component.ts
@@ -18,7 +18,7 @@ export class SpecificationSearchComponent implements OnInit {
   }
 
   public searchForString(event) {
-    if (event.keyCode === 13) {
+    if (event.keyCode === 13 && this.searchString !== undefined && this.searchString !== '') {
       this.router.navigate(['search', this.searchString]);
       this.searchString = '';
     }


### PR DESCRIPTION
Found when testing

Details:
- Corrects a method name that was accidentally skipped in the grand `Specification` -> `Service` renaming
- The test `services.length == 0` was occurring before the services list was defined, resulting in a frontend console error. Now there's a boolean to guard this field before the data comes through
- Pressing enter in an empty search box will not update the results or refresh the page
- If the user entered only characters that are filtered out by Spring's controllers (eg. just `#`, or ` `), so that the `@PathVariable` would end up blank, the route requested of the backend was `/api/v1/search/`. This is not matched by any controller, resulting in an uncaught server error. (Open to alternative suggestions on how to solve this than the one in this PR)