### PR TITLE
Prereleases and snapshot versions

### DIFF
--- a/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerIntegrationTest.kt
+++ b/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerIntegrationTest.kt
@@ -86,7 +86,7 @@ internal class ServiceControllerIntegrationTest {
                         .with(csrf())
                         .contentType("application/json")
                         .content("""
-                           [{"fileContent":"t","metadata":{"title":"My title","version":"3.0.0","description":"","language":"GRAPHQL","endpointUrl":""}}]
+                           [{"fileContent":"t","metadata":{"title":"My title","version":"3.0.0","description":"","language":"GRAPHQL","releaseType":"RELEASE","endpointUrl":""}}]
                         """.trimIndent()
                         )
         )
@@ -131,6 +131,26 @@ internal class ServiceControllerIntegrationTest {
                         )
         )
                 .andExpect(status().isConflict)
+    }
+
+    @Test
+    fun uploadSpecification_shouldDetectVersionClash_overwriteSnapshot() {
+        mockMvc.perform(
+                post("/api/v1/service")
+                        .with(user("user"))
+                        .with(csrf())
+                        .contentType("application/json")
+                        .content(
+                                """
+                            | {
+                            |   "id": "unique-identifier-2",
+                            |   "fileContent": "{\"info\": {\"title\": \"Spec1\",  \"version\": \"1.0.0-SNAPSHOT\", \"description\": \"I'm different\"}}"
+                            | }
+                            """.trimMargin()
+                        )
+        )
+                .andExpect(status().isCreated)
+                .andExpect(jsonPath("$.metadata.description", equalTo("I'm different")))
     }
 
     @Test

--- a/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerIntegrationTest.kt
+++ b/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerIntegrationTest.kt
@@ -86,7 +86,7 @@ internal class ServiceControllerIntegrationTest {
                         .with(csrf())
                         .contentType("application/json")
                         .content("""
-                           [{"fileContent":"t","metadata":{"title":"My title","version":"3.0.0","description":"","language":"GRAPHQL","releaseType":"RELEASE","endpointUrl":""}}]
+                           [{"fileContent":"t","metadata":{"title":"My title","version":"3.0.0","description":"","language":"GRAPHQL","endpointUrl":""}}]
                         """.trimIndent()
                         )
         )
@@ -142,15 +142,15 @@ internal class ServiceControllerIntegrationTest {
                         .contentType("application/json")
                         .content(
                                 """
-                            | {
+                            | [{
                             |   "id": "unique-identifier-2",
                             |   "fileContent": "{\"info\": {\"title\": \"Spec1\",  \"version\": \"1.0.0-SNAPSHOT\", \"description\": \"I'm different\"}}"
-                            | }
+                            | }]
                             """.trimMargin()
                         )
         )
                 .andExpect(status().isCreated)
-                .andExpect(jsonPath("$.metadata.description", equalTo("I'm different")))
+                .andExpect(jsonPath("$[0].metadata.description", equalTo("I'm different")))
     }
 
     @Test

--- a/backend/src/integration-test/resources/data.sql
+++ b/backend/src/integration-test/resources/data.sql
@@ -2,10 +2,12 @@ INSERT INTO SERVICE_ENTITY VALUES ('b6b06513-d259-4faf-b34b-a216b3daad6a', 'Desc
 INSERT INTO SERVICE_ENTITY VALUES ('f67cb0a6-c31b-424b-bfbb-ab0e163955ca', 'Description', 'remoteUrl', 'Spec2');
 INSERT INTO SERVICE_ENTITY VALUES ('af0502a2-7410-40e4-90fd-3504f67de1ee', 'Description', 'remoteUrl', 'Spec3');
 INSERT INTO SERVICE_ENTITY VALUES ('unique-identifier',                    'Description', 'remoteUrl', 'Spec4');
+INSERT INTO SERVICE_ENTITY VALUES ('unique-identifier-2',                  'Description', 'remoteUrl', 'Spec4');
 
-INSERT INTO SPECIFICATION_ENTITY VALUES('1.0.0', '{"info": {"title": "Spec1",  "version": "1.0.0", "description": "Description"}}' , '2018-01-01 11:00:00.000', 'Description', '', '0', 'Spec1', 'b6b06513-d259-4faf-b34b-a216b3daad6a');
-INSERT INTO SPECIFICATION_ENTITY VALUES('1.0.0', '{"info": {"title": "Spec4",  "version": "1.0.0", "description": "Description"}}' , '2018-01-01 11:00:00.000', 'Description', '', '0', 'Spec4', 'unique-identifier');
-INSERT INTO SPECIFICATION_ENTITY VALUES('1.0.0', '{"info": {"title": "Spec2",  "version": "1.0.0", "description": "Description"}}' , '2018-01-01 11:00:00.000', 'Description', '', '0', 'Spec2', 'f67cb0a6-c31b-424b-bfbb-ab0e163955ca');
-INSERT INTO SPECIFICATION_ENTITY VALUES('2.0.0', '{"info": {"title": "Spec2",  "version": "2.0.0", "description": "Description"}}' , '2018-01-01 10:00:00.000', 'Description', '', '0', 'Spec2', 'f67cb0a6-c31b-424b-bfbb-ab0e163955ca');
-INSERT INTO SPECIFICATION_ENTITY VALUES('1.0.0','{"info": {"title": "Spec3",  "version": "1.0.0", "description": "Description"}}', '2018-01-01 11:00:00.000', 'Description', '', '0', 'Spec3', 'af0502a2-7410-40e4-90fd-3504f67de1ee');
-INSERT INTO SPECIFICATION_ENTITY VALUES('1.1.0','{"info": {"title": "Spec3",  "version": "1.1.0", "description": "Description"}}', '2018-01-01 10:00:00.000', 'Description', '', '0', 'Spec3', 'af0502a2-7410-40e4-90fd-3504f67de1ee');
+INSERT INTO SPECIFICATION_ENTITY VALUES('1.0.0', '{"info": {"title": "Spec1",  "version": "1.0.0", "description": "Description"}}' , '2018-01-01 11:00:00.000', 'Description', '', '0', '0', 'Spec1', 'b6b06513-d259-4faf-b34b-a216b3daad6a');
+INSERT INTO SPECIFICATION_ENTITY VALUES('1.0.0', '{"info": {"title": "Spec4",  "version": "1.0.0", "description": "Description"}}' , '2018-01-01 11:00:00.000', 'Description', '', '0', '0', 'Spec4', 'unique-identifier');
+INSERT INTO SPECIFICATION_ENTITY VALUES('1.0.0-SNAPSHOT', '{"info": {"title": "Spec4",  "version": "1.0.0-SNAPSHOT", "description": "Description"}}' , '2018-01-01 11:00:00.000', 'Description', '', '0', '0', 'Spec4', 'unique-identifier-2');
+INSERT INTO SPECIFICATION_ENTITY VALUES('1.0.0', '{"info": {"title": "Spec2",  "version": "1.0.0", "description": "Description"}}' , '2018-01-01 11:00:00.000', 'Description', '', '0', '0', 'Spec2', 'f67cb0a6-c31b-424b-bfbb-ab0e163955ca');
+INSERT INTO SPECIFICATION_ENTITY VALUES('2.0.0', '{"info": {"title": "Spec2",  "version": "2.0.0", "description": "Description"}}' , '2018-01-01 10:00:00.000', 'Description', '', '0', '0', 'Spec2', 'f67cb0a6-c31b-424b-bfbb-ab0e163955ca');
+INSERT INTO SPECIFICATION_ENTITY VALUES('1.0.0','{"info": {"title": "Spec3",  "version": "1.0.0", "description": "Description"}}', '2018-01-01 11:00:00.000', 'Description', '', '0', '0', 'Spec3', 'af0502a2-7410-40e4-90fd-3504f67de1ee');
+INSERT INTO SPECIFICATION_ENTITY VALUES('1.1.0','{"info": {"title": "Spec3",  "version": "1.1.0", "description": "Description"}}', '2018-01-01 10:00:00.000', 'Description', '', '0', '0', 'Spec3', 'af0502a2-7410-40e4-90fd-3504f67de1ee');

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/entity/SpecificationEntity.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/entity/SpecificationEntity.kt
@@ -1,6 +1,7 @@
 package com.tngtech.apicenter.backend.connector.database.entity
 
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
+import com.tngtech.apicenter.backend.domain.entity.ReleaseType
 import org.hibernate.search.annotations.ContainedIn
 import org.hibernate.search.annotations.Field
 import org.hibernate.search.annotations.IndexedEmbedded
@@ -23,6 +24,7 @@ data class SpecificationEntity(
         @Field @Column(columnDefinition = "TEXT") val title: String,
         @Field @Column(columnDefinition = "TEXT") val description: String?,
         @Field @Column(columnDefinition = "TEXT") val language: ApiLanguage,
+        @Field @Column(columnDefinition = "TEXT") val releaseType: ReleaseType,
         @Field @Column(columnDefinition = "TEXT") val endpointUrl: String?,
         @ContainedIn @ManyToOne @MapsId("serviceId") var service: ServiceEntity?,
         var created: Date?

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/mapper/converter/SpecificationEntityConverter.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/mapper/converter/SpecificationEntityConverter.kt
@@ -22,6 +22,7 @@ class SpecificationEntityConverter : BidirectionalConverter<Specification, Speci
                     source.specificationId.version,
                     source.description,
                     source.language,
+                    source.releaseType,
                     source.endpointUrl
             )
         )
@@ -35,6 +36,7 @@ class SpecificationEntityConverter : BidirectionalConverter<Specification, Speci
                         source.metadata.title,
                         source.metadata.description,
                         source.metadata.language,
+                        source.metadata.releaseType,
                         source.metadata.endpointUrl,
                         null,
                         null

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/ServiceDatabase.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/ServiceDatabase.kt
@@ -21,13 +21,13 @@ class ServiceDatabase constructor(
 ) : ServicePersistor {
 
     override fun save(service: Service) {
-        val specificationEntity = serviceEntityMapper.fromDomain(service)
-        specificationEntity.specifications.map { versionEntity -> versionEntity.service = specificationEntity }
+        val serviceEntity = serviceEntityMapper.fromDomain(service)
+        serviceEntity.specifications.map { specificationEntity -> specificationEntity.service = serviceEntity }
 
         try {
-            serviceRepository.save(specificationEntity)
+            serviceRepository.save(serviceEntity)
         } catch (sqlException: DataIntegrityViolationException) {
-            throw SpecificationAlreadyExistsException(specificationEntity.title)
+            throw SpecificationAlreadyExistsException(serviceEntity.title)
         }
     }
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationFileDto.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationFileDto.kt
@@ -2,12 +2,14 @@ package com.tngtech.apicenter.backend.connector.rest.dto
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
+import com.tngtech.apicenter.backend.domain.entity.ReleaseType
 
 data class SpecificationFileMetadata constructor(
     val title: String,
     val version: String,
     val description: String?,
     val language: ApiLanguage,
+    val releaseType: ReleaseType,
     val endpointUrl: String? = null
 )
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationFileDto.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationFileDto.kt
@@ -2,7 +2,6 @@ package com.tngtech.apicenter.backend.connector.rest.dto
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
-import com.tngtech.apicenter.backend.domain.entity.ReleaseType
 
 data class SpecificationFileMetadata constructor(
     val title: String,

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationFileDto.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationFileDto.kt
@@ -9,7 +9,6 @@ data class SpecificationFileMetadata constructor(
     val version: String,
     val description: String?,
     val language: ApiLanguage,
-    val releaseType: ReleaseType,
     val endpointUrl: String? = null
 )
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataParser.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataParser.kt
@@ -10,6 +10,7 @@ import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileMetadat
 import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
 import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.SpecificationMetadata
+import com.tngtech.apicenter.backend.domain.entity.inferReleaseType
 import com.tngtech.apicenter.backend.domain.exceptions.MismatchedServiceIdException
 import com.tngtech.apicenter.backend.domain.exceptions.SpecificationParseException
 import org.springframework.beans.factory.annotation.Autowired
@@ -111,6 +112,7 @@ class SpecificationDataParser @Autowired constructor(
                     version,
                     metadata.description,
                     ApiLanguage.GRAPHQL,
+                    metadata.releaseType,
                     metadata.endpointUrl
             )
         } else {
@@ -120,6 +122,7 @@ class SpecificationDataParser @Autowired constructor(
                     version,
                     extractDescription(fileContent),
                     ApiLanguage.OPENAPI,
+                    inferReleaseType(version),
                     null
             )
         }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataParser.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataParser.kt
@@ -7,10 +7,7 @@ import com.github.zafarkhaja.semver.UnexpectedCharacterException
 import com.jayway.jsonpath.JsonPath
 import com.jayway.jsonpath.PathNotFoundException
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileMetadata
-import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
-import com.tngtech.apicenter.backend.domain.entity.ServiceId
-import com.tngtech.apicenter.backend.domain.entity.SpecificationMetadata
-import com.tngtech.apicenter.backend.domain.entity.inferReleaseType
+import com.tngtech.apicenter.backend.domain.entity.*
 import com.tngtech.apicenter.backend.domain.exceptions.MismatchedServiceIdException
 import com.tngtech.apicenter.backend.domain.exceptions.SpecificationParseException
 import org.springframework.beans.factory.annotation.Autowired
@@ -112,7 +109,7 @@ class SpecificationDataParser @Autowired constructor(
                     version,
                     metadata.description,
                     ApiLanguage.GRAPHQL,
-                    metadata.releaseType,
+                    ReleaseType.fromVersionString(metadata.version),
                     metadata.endpointUrl
             )
         } else {
@@ -122,7 +119,7 @@ class SpecificationDataParser @Autowired constructor(
                     version,
                     extractDescription(fileContent),
                     ApiLanguage.OPENAPI,
-                    inferReleaseType(version),
+                    ReleaseType.fromVersionString(version),
                     null
             )
         }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Service.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Service.kt
@@ -21,4 +21,21 @@ class Service(
                 this.remoteAddress
         )
     }
+
+    fun overwriteSpecificationContents(newSpec: Specification): Service {
+        val specifications = this.specifications.map { spec ->
+            if (spec.metadata.version == newSpec.metadata.version) {
+                newSpec
+            } else {
+                spec
+            }
+        }
+        return Service(
+                this.id,
+                this.title,
+                this.description,
+                specifications,
+                this.remoteAddress
+        )
+    }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Specification.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Specification.kt
@@ -3,19 +3,18 @@ package com.tngtech.apicenter.backend.domain.entity
 import java.util.regex.Pattern
 
 enum class ReleaseType {
-    RELEASE, PRERELEASE, SNAPSHOT
-}
+    RELEASE, PRERELEASE, SNAPSHOT;
 
-fun inferReleaseType(version: String): ReleaseType {
-    return if (version.endsWith("-SNAPSHOT")) {
-        ReleaseType.SNAPSHOT
-    } else if (Pattern.matches("-BETA\\d*", version) || Pattern.matches("-RC\\d*", version)) {
-        ReleaseType.PRERELEASE
-    } else {
-        ReleaseType.RELEASE
+    companion object {
+        fun fromVersionString(version: String): ReleaseType {
+            return when {
+                version.endsWith("-SNAPSHOT") -> SNAPSHOT
+                Pattern.matches("-(BETA|RC)\\d*", version) -> PRERELEASE
+                else -> RELEASE
+            }
+        }
     }
 }
-
 
 data class SpecificationMetadata constructor(
     val id: ServiceId,

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Specification.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Specification.kt
@@ -1,11 +1,16 @@
 package com.tngtech.apicenter.backend.domain.entity
 
+enum class ReleaseType {
+    RELEASE, PRERELEASE, SNAPSHOT
+}
+
 data class SpecificationMetadata constructor(
     val id: ServiceId,
     val title: String,
     val version: String,
     val description: String?,
     val language: ApiLanguage,
+    val releaseType: ReleaseType,
     val endpointUrl: String? = null
 )
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Specification.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/Specification.kt
@@ -1,8 +1,21 @@
 package com.tngtech.apicenter.backend.domain.entity
 
+import java.util.regex.Pattern
+
 enum class ReleaseType {
     RELEASE, PRERELEASE, SNAPSHOT
 }
+
+fun inferReleaseType(version: String): ReleaseType {
+    return if (version.endsWith("-SNAPSHOT")) {
+        ReleaseType.SNAPSHOT
+    } else if (Pattern.matches("-BETA\\d*", version) || Pattern.matches("-RC\\d*", version)) {
+        ReleaseType.PRERELEASE
+    } else {
+        ReleaseType.RELEASE
+    }
+}
+
 
 data class SpecificationMetadata constructor(
     val id: ServiceId,

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/handler/ServiceHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/handler/ServiceHandler.kt
@@ -1,5 +1,6 @@
 package com.tngtech.apicenter.backend.domain.handler
 
+import com.tngtech.apicenter.backend.domain.entity.ReleaseType
 import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Service
 import com.tngtech.apicenter.backend.domain.entity.Specification
@@ -47,7 +48,11 @@ class ServiceHandler @Autowired constructor(
             if (existingContents == specification.content) {
                 throw SpecificationDuplicationException()
             } else {
-                throw SpecificationConflictException()
+                if (specification.metadata.releaseType == ReleaseType.SNAPSHOT) {
+                    servicePersistor.save(service.overwriteSpecificationContents(specification))
+                } else {
+                    throw SpecificationConflictException()
+                }
             }
         } else {
             servicePersistor.save(service.appendSpecification(specification))

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerUnitTest.kt
@@ -21,7 +21,7 @@ internal class ServiceControllerUnitTest {
             "{\"swagger\": \"2.0\", \"info\": {\"version\": \"1.0.0\",\"title\": \"Swagger Petstore\",\"description\":\"Description\"}}"
         const val UUID_STRING = "65d8491f-e602-40fc-a595-45e75f690df1"
     }
-    private val metadata = SpecificationMetadata(ServiceId(UUID_STRING), "Swagger Petstore", "1.0.0", "Description", ApiLanguage.OPENAPI, null)
+    private val metadata = SpecificationMetadata(ServiceId(UUID_STRING), "Swagger Petstore", "1.0.0", "Description", ApiLanguage.OPENAPI, ReleaseType.RELEASE, null)
 
     private val serviceHandler: ServiceHandler = mock()
 

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/SpecificationControllerUnitTest.kt
@@ -5,10 +5,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationDto
 import com.tngtech.apicenter.backend.connector.rest.mapper.SpecificationFileDtoMapper
-import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
-import com.tngtech.apicenter.backend.domain.entity.ServiceId
-import com.tngtech.apicenter.backend.domain.entity.Specification
-import com.tngtech.apicenter.backend.domain.entity.SpecificationMetadata
+import com.tngtech.apicenter.backend.domain.entity.*
 import com.tngtech.apicenter.backend.domain.service.SpecificationPersistor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -23,7 +20,7 @@ internal class SpecificationControllerUnitTest {
 
     private val serviceId = "7de07d27-eedb-4290-881a-6a402a81dd0f"
 
-    private val metadata = SpecificationMetadata(ServiceId(serviceId), "Swagger Petstore", "1.0.0", "Description", ApiLanguage.OPENAPI, null)
+    private val metadata = SpecificationMetadata(ServiceId(serviceId), "Swagger Petstore", "1.0.0", "Description", ApiLanguage.OPENAPI, ReleaseType.RELEASE, null)
 
     private val specification = Specification("Content", metadata)
 

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationFileDtoConverterTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/mapper/converter/SpecificationFileDtoConverterTest.kt
@@ -3,13 +3,10 @@ package com.tngtech.apicenter.backend.connector.rest.mapper.converter
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileDto
 import com.tngtech.apicenter.backend.connector.rest.service.SpecificationDataParser
 import com.tngtech.apicenter.backend.connector.rest.service.SpecificationFileDownloader
-import com.tngtech.apicenter.backend.domain.entity.Specification
 import com.nhaarman.mockitokotlin2.given
 import com.nhaarman.mockitokotlin2.mock
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileMetadata
-import com.tngtech.apicenter.backend.domain.entity.ApiLanguage
-import com.tngtech.apicenter.backend.domain.entity.ServiceId
-import com.tngtech.apicenter.backend.domain.entity.SpecificationMetadata
+import com.tngtech.apicenter.backend.domain.entity.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -22,7 +19,7 @@ class SpecificationFileDtoConverterTest {
         const val SWAGGER_REMOTE = "https://swagger.com/remote/file.json"
         const val UUID_STRING = "5aa40ba9-7e26-44de-81ec-f545d1f178aa"
     }
-    private val metadata = SpecificationMetadata(ServiceId(UUID_STRING), "Swagger Petstore", "1.0.0", "Description", ApiLanguage.OPENAPI, null)
+    private val metadata = SpecificationMetadata(ServiceId(UUID_STRING), "Swagger Petstore", "1.0.0", "Description", ApiLanguage.OPENAPI, ReleaseType.RELEASE, null)
 
     private val specificationDataParser: SpecificationDataParser = mock()
 

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/RemoteServiceUpdaterTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/service/RemoteServiceUpdaterTest.kt
@@ -28,7 +28,7 @@ class RemoteServiceUpdaterTest {
         const val REMOTE_ADDRESS = "http://testapi.com/testapi.json"
     }
 
-    private val metadata = SpecificationMetadata(ServiceId(SPECIFICATION_ID), "Swagger Petstore", "1.0.0", "Description", ApiLanguage.OPENAPI, null)
+    private val metadata = SpecificationMetadata(ServiceId(SPECIFICATION_ID), "Swagger Petstore", "1.0.0", "Description", ApiLanguage.OPENAPI, ReleaseType.RELEASE, null)
 
     @Test
     fun synchronize_shouldStoreUpdatedService() {

--- a/frontend/src/app/models/specification.ts
+++ b/frontend/src/app/models/specification.ts
@@ -11,16 +11,6 @@ export enum ReleaseType {
   Snapshot = 'SNAPSHOT',
 }
 
-export function inferReleaseType(version: string): ReleaseType {
-  if (version.endsWith('-SNAPSHOT')) {
-    return ReleaseType.Snapshot;
-  } else if (/-BETA\d*/.test(version) || /-RC\d*/.test(version)) {
-    return ReleaseType.Prerelease;
-  } else {
-    return ReleaseType.Release;
-  }
-}
-
 export class Specification {
   content: string;
   metadata: SpecificationMetadata;

--- a/frontend/src/app/models/specification.ts
+++ b/frontend/src/app/models/specification.ts
@@ -5,6 +5,22 @@ export enum ApiLanguage {
   GraphQL = 'GRAPHQL',
 }
 
+export enum ReleaseType {
+  Release = 'RELEASE',
+  Prerelease = 'PRERELEASE',
+  Snapshot = 'SNAPSHOT',
+}
+
+export function inferReleaseType(version: string): ReleaseType {
+  if (version.endsWith('-SNAPSHOT')) {
+    return ReleaseType.Snapshot;
+  } else if (/-BETA\d*/.test(version) || /-RC\d*/.test(version)) {
+    return ReleaseType.Prerelease;
+  } else {
+    return ReleaseType.Release;
+  }
+}
+
 export class Specification {
   content: string;
   metadata: SpecificationMetadata;

--- a/frontend/src/app/models/specificationfile.ts
+++ b/frontend/src/app/models/specificationfile.ts
@@ -1,4 +1,4 @@
-import {ApiLanguage} from './specification';
+import {ApiLanguage, ReleaseType} from './specification';
 
 export interface SpecificationMetadata {
   title: string;
@@ -6,6 +6,7 @@ export interface SpecificationMetadata {
   description?: string;
   language: ApiLanguage;
   endpointUrl?: string;
+  releaseType: ReleaseType;
 }
 
 export class SpecificationFile {

--- a/frontend/src/app/models/specificationfile.ts
+++ b/frontend/src/app/models/specificationfile.ts
@@ -9,13 +9,21 @@ export interface SpecificationMetadata {
   releaseType: ReleaseType;
 }
 
+export interface SpecificationFileMetadata {
+  title: string;
+  version: string;
+  description: string;
+  language: ApiLanguage;
+  endpointUrl: string;
+}
+
 export class SpecificationFile {
-  metadata?: SpecificationMetadata;
+  metadata?: SpecificationFileMetadata;
   fileContent: string;
   fileUrl: string;
   id?: string;
 
-  constructor(fileContent: string, fileUrl: string, id?: string, metadata?: SpecificationMetadata) {
+  constructor(fileContent: string, fileUrl: string, id?: string, metadata?: SpecificationFileMetadata) {
     this.fileContent = fileContent;
     this.fileUrl = fileUrl;
     this.id = id;

--- a/frontend/src/app/service-store.service.spec.ts
+++ b/frontend/src/app/service-store.service.spec.ts
@@ -5,7 +5,7 @@ import {Service} from './models/service';
 import {from} from 'rxjs/observable/from';
 import 'rxjs/add/operator/catch';
 import {SpecificationFile} from './models/specificationfile';
-import {ApiLanguage, Specification} from './models/specification';
+import {ApiLanguage, ReleaseType, Specification} from './models/specification';
 
 describe('ServiceStore', () => {
 
@@ -17,6 +17,7 @@ describe('ServiceStore', () => {
     version: '1.0.0',
     description: 'Description',
     language: ApiLanguage.OpenAPI,
+    releaseType: ReleaseType.Release,
     endpointUrl: null,
   };
 

--- a/frontend/src/app/specification-form/specification-form.component.ts
+++ b/frontend/src/app/specification-form/specification-form.component.ts
@@ -3,7 +3,7 @@ import {ActivatedRoute, Router} from '@angular/router';
 import {SpecificationFile, SpecificationFileMetadata, SpecificationMetadata} from '../models/specificationfile';
 import {ServiceStore} from '../service-store.service';
 import {Service} from '../models/service';
-import {ApiLanguage, inferReleaseType, ReleaseType} from '../models/specification';
+import {ApiLanguage} from '../models/specification';
 import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {animate, style, transition, trigger} from '@angular/animations';
 

--- a/frontend/src/app/specification-form/specification-form.component.ts
+++ b/frontend/src/app/specification-form/specification-form.component.ts
@@ -3,7 +3,7 @@ import {ActivatedRoute, Router} from '@angular/router';
 import {SpecificationFile, SpecificationMetadata} from '../models/specificationfile';
 import {ServiceStore} from '../service-store.service';
 import {Service} from '../models/service';
-import {ApiLanguage} from '../models/specification';
+import {ApiLanguage, inferReleaseType, ReleaseType} from '../models/specification';
 import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {animate, style, transition, trigger} from '@angular/animations';
 

--- a/frontend/src/app/specification-form/specification-form.component.ts
+++ b/frontend/src/app/specification-form/specification-form.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
-import {SpecificationFile, SpecificationMetadata} from '../models/specificationfile';
+import {SpecificationFile, SpecificationFileMetadata, SpecificationMetadata} from '../models/specificationfile';
 import {ServiceStore} from '../service-store.service';
 import {Service} from '../models/service';
 import {ApiLanguage, inferReleaseType, ReleaseType} from '../models/specification';
@@ -127,7 +127,7 @@ export class SpecificationFormComponent implements OnInit {
 
       reader.onload = function () {
         const fileContent = reader.result.toString();
-        const metadata: SpecificationMetadata = me.showAdditionalMetadataFields ?
+        const metadata: SpecificationFileMetadata = me.showAdditionalMetadataFields ?
           {...me.additionalFields, language: ApiLanguage.GraphQL}
           : null;
         const file = new SpecificationFile(fileContent, null, me.id, metadata);

--- a/frontend/src/app/specification-overview/specification-overview.component.html
+++ b/frontend/src/app/specification-overview/specification-overview.component.html
@@ -41,10 +41,14 @@
                     data-toggle="collapse" [attr.data-target]="'#versions-' + service.id"></span>
             </td>
             <td>
-              <a [routerLink]="['specifications/', service.id, service.specifications[0].metadata.version]"
+              <a [routerLink]="[
+                                'specifications/',
+                                service.id,
+                                getFirstRelease(service)
+                                ]"
                  routerLinkActive="active">{{service.title}}</a>
             </td>
-            <td>{{ service.specifications[0].metadata.version }}</td>
+            <td>{{ getFirstRelease(service) }}</td>
             <td>
               <button class="btn oi oi-loop-circular" title="Check for updates" *ngIf="service.remoteAddress != null"
                       (click)="synchronize(service)"></button>

--- a/frontend/src/app/specification-overview/specification-overview.component.html
+++ b/frontend/src/app/specification-overview/specification-overview.component.html
@@ -63,7 +63,7 @@
           <tbody [attr.id]="'versions-' + service.id" class="collapse" *ngIf="service.specifications.length > 1">
           <tr *ngFor="let specification of service.specifications">
             <td></td>
-            <td><a [routerLink]="['specifications/', service.id, specification.metadata.version]" routerLinkActive="active">{{ service.title }}</a></td>
+            <td><a [routerLink]="['specifications/', service.id, specification.metadata.version]" routerLinkActive="active">{{ specification.metadata.title }}</a></td>
             <td>{{ specification.metadata.version }}</td>
             <td>
               <button class="btn oi oi-data-transfer-download" title="Download" (click)="downloadSpecification(selectedFormat, service, specification)"></button>

--- a/frontend/src/app/specification-overview/specification-overview.component.html
+++ b/frontend/src/app/specification-overview/specification-overview.component.html
@@ -44,11 +44,11 @@
               <a [routerLink]="[
                                 'specifications/',
                                 service.id,
-                                getFirstRelease(service)
+                                getFirstRelease(service).metadata.version
                                 ]"
-                 routerLinkActive="active">{{service.title}}</a>
+                 routerLinkActive="active">{{getFirstRelease(service).metadata.title}}</a>
             </td>
-            <td>{{ getFirstRelease(service) }}</td>
+            <td>{{ getFirstRelease(service).metadata.version }}</td>
             <td>
               <button class="btn oi oi-loop-circular" title="Check for updates" *ngIf="service.remoteAddress != null"
                       (click)="synchronize(service)"></button>

--- a/frontend/src/app/specification-overview/specification-overview.component.spec.ts
+++ b/frontend/src/app/specification-overview/specification-overview.component.spec.ts
@@ -3,7 +3,7 @@ import {instance, mock, verify, when} from 'ts-mockito';
 import {ServiceStore} from '../service-store.service';
 import {Service} from '../models/service';
 import {from} from 'rxjs/observable/from';
-import {ApiLanguage, Specification} from '../models/specification';
+import {ApiLanguage, ReleaseType, Specification} from '../models/specification';
 import {SpecificationStore} from '../specification-store.service';
 import {Title} from '@angular/platform-browser';
 
@@ -20,6 +20,7 @@ describe('SpecificationOverviewComponent', () => {
     version: '1.0.0',
     description: 'Description',
     language: ApiLanguage.OpenAPI,
+    releaseType: ReleaseType.Release,
     endpointUrl: null,
   })];
   const service = new Service('b0fb472d-bee2-47b6-8ecf-ee5e1e76e990', 'Test', 'Description', specifications, null);

--- a/frontend/src/app/specification-overview/specification-overview.component.ts
+++ b/frontend/src/app/specification-overview/specification-overview.component.ts
@@ -162,11 +162,11 @@ export class SpecificationOverviewComponent implements OnInit {
    );
   }
 
-  public getFirstRelease(service: Service): string {
+  public getFirstRelease(service: Service): Specification {
     return (
       service.specifications
         .find(spec => spec.metadata.releaseType === ReleaseType.Release)
       || service.specifications[0]
-    ).metadata.version;
+    );
   }
 }

--- a/frontend/src/app/specification-overview/specification-overview.component.ts
+++ b/frontend/src/app/specification-overview/specification-overview.component.ts
@@ -68,7 +68,7 @@ export class SpecificationOverviewComponent implements OnInit {
   }
 
   public async downloadService(service: Service, fileType: string) {
-    this.downloadSpecification(fileType, service, service.specifications[0]);
+    this.downloadSpecification(fileType, service, this.getFirstRelease(service));
   }
 
   public downloadSpecification(fileType: string, service: Service, specification: Specification) {
@@ -76,7 +76,7 @@ export class SpecificationOverviewComponent implements OnInit {
       case ApiLanguage.GraphQL:
         this.specificationStore.getSpecification(service.id, specification.metadata.version)
           .subscribe(event => {
-            const fileName = this.createDownloadFileName(service, specification);
+            const fileName = this.createDownloadFileName(specification);
             this.doDownload(event.content, fileName + '.graphql', 'application/json');
           });
         break;
@@ -89,7 +89,7 @@ export class SpecificationOverviewComponent implements OnInit {
   public downloadOpenApi(fileType: string, service: Service, specification: Specification) {
     switch (fileType) {
       case 'json':
-        this.downloadJson(service, specification);
+        this.downloadJson(specification);
         break;
       case 'yaml':
         this.downloadYaml(service, specification);
@@ -97,14 +97,14 @@ export class SpecificationOverviewComponent implements OnInit {
     }
   }
 
-  public downloadJson(service: Service, specification: Specification) {
-    const fileName = this.createDownloadFileName(service, specification);
+  public downloadJson(specification: Specification) {
+    const fileName = this.createDownloadFileName(specification);
     const content = JSON.stringify(JSON.parse(specification.content), null, 2);
     this.doDownload(content, fileName + '.json', 'application/json');
   }
 
   public downloadYaml(service: Service, specification: Specification) {
-    const fileName = this.createDownloadFileName(service, specification);
+    const fileName = this.createDownloadFileName(specification);
     this.specificationStore.getYamlSpecification(service.id, specification.metadata.version)
       .subscribe(event => {
         this.doDownload(event.content, fileName + '.yml', 'application/yaml');
@@ -123,9 +123,9 @@ export class SpecificationOverviewComponent implements OnInit {
     document.body.removeChild(anchor);
   }
 
-  private createDownloadFileName(service: Service, specification: Specification) {
+  private createDownloadFileName(specification: Specification) {
     // Make it filename safe by replacing any non-alphanumeric character with an underscore
-    return (service.title + '_v' + specification.metadata.version).replace(/[^a-z0-9\.]/gi, '_');
+    return (specification.metadata.title + '_v' + specification.metadata.version).replace(/[^a-z0-9\.]/gi, '_');
   }
 
   public async synchronize(service: Service) {

--- a/frontend/src/app/specification-overview/specification-overview.component.ts
+++ b/frontend/src/app/specification-overview/specification-overview.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import {ServiceStore} from '../service-store.service';
 import {Service} from '../models/service';
-import {ApiLanguage, Specification} from '../models/specification';
+import {ApiLanguage, ReleaseType, Specification} from '../models/specification';
 import {SpecificationStore} from '../specification-store.service';
 import {Title} from '@angular/platform-browser';
 import {animate, state, style, transition, trigger} from '@angular/animations';
@@ -160,5 +160,13 @@ export class SpecificationOverviewComponent implements OnInit {
        }
      }
    );
+  }
+
+  public getFirstRelease(service: Service): string {
+    return (
+      service.specifications
+        .find(spec => spec.metadata.releaseType === ReleaseType.Release)
+      || service.specifications[0]
+    ).metadata.version;
   }
 }

--- a/frontend/src/app/specification-search-detail/specification-search-detail.component.spec.ts
+++ b/frontend/src/app/specification-search-detail/specification-search-detail.component.spec.ts
@@ -4,7 +4,7 @@ import {instance, mock, verify, when} from 'ts-mockito';
 import {ActivatedRoute} from '@angular/router';
 import {Service} from '../models/service';
 import {from} from 'rxjs/index';
-import {ApiLanguage, Specification} from '../models/specification';
+import {ApiLanguage, ReleaseType, Specification} from '../models/specification';
 
 describe('SpecificationSearchDetailComponent', () => {
   let specificationSearchDetailComponent: SpecificationSearchDetailComponent;
@@ -17,6 +17,7 @@ describe('SpecificationSearchDetailComponent', () => {
     version: '1.0',
     description: 'Description',
     language: ApiLanguage.OpenAPI,
+    releaseType: ReleaseType.Release,
     endpointUrl: null,
   })];
   const services = [new Service('b0fb472d-bee2-47b6-8ecf-ee5e1e76e990', 'Test', 'Description', specifications, null)];


### PR DESCRIPTION
Close #63 and close #64. Grouped these, as they are closely related when considering changes to the specification data model.

- The main version is that latest which is non-snapshot and non-prerelease, and only visible after expanding a table node in the overview
- When uploading a snapshot version, permit overriding of the specification content

![snapshots](https://user-images.githubusercontent.com/6897716/60271437-a5a3e500-98f2-11e9-85a4-b033138ab30a.gif)