### PR TITLE
Display error inside file upload modal

### DIFF
--- a/frontend/src/app/specification-form/specification-form.component.html
+++ b/frontend/src/app/specification-form/specification-form.component.html
@@ -1,21 +1,18 @@
 <div class="container top-buffer">
-  <div class="row top-buffer">
-    <div class="alert alert-danger" role="alert" *ngIf="error">
-      {{ error }}
-    </div>
-  </div>
-
   <h4>Upload a specification...</h4>
   <br>
 
   <ng-template #local let-modal>
     <div class="modal-header">
       <h4 class="modal-title">Local file upload</h4>
-      <button type="button" class="close" aria-label="Close" (click)="modal.dismiss('Cross click')">
+      <button type="button" class="close" aria-label="Close" (click)="modal.dismiss()">
         <span aria-hidden="true">&times;</span>
       </button>
     </div>
     <div class="modal-body">
+       <div class="alert alert-danger" role="alert" *ngIf="error">
+         {{ error }}
+       </div>
        <input type="file" placeholder="Upload Swagger Specification" accept=".yml,.json,.yaml,.graphql" ngModel
          (change)="onLocalFileChange($event)">
 
@@ -36,7 +33,7 @@
     </div>
 
     <div class="modal-footer">
-      <button type="button" class="btn btn-outline-dark" (click)="submitLocalSpecification() && modal.close()">Upload</button>
+      <button type="button" class="btn btn-outline-dark" (click)="submitLocalSpecification()">Upload</button>
     </div>
   </ng-template>
 
@@ -48,6 +45,9 @@
       </button>
     </div>
     <div class="modal-body">
+      <div class="alert alert-danger" role="alert" *ngIf="error">
+        {{ error }}
+      </div>
       <p>
         Enter the name of a URL, where the specification file is hosted.
         ApiCenter will download the specification and add it to the database.
@@ -56,7 +56,7 @@
       <input type="text" title="url" placeholder="Insert URL here" [(ngModel)]="remoteFileUrl"/>
     </div>
     <div class="modal-footer">
-      <button type="button" class="btn btn-outline-dark" (click)="submitRemoteSpecification() && modal.close()">Upload</button>
+      <button type="button" class="btn btn-outline-dark" (click)="submitRemoteSpecification()">Upload</button>
     </div>
   </ng-template>
 

--- a/frontend/src/app/specification-form/specification-form.component.ts
+++ b/frontend/src/app/specification-form/specification-form.component.ts
@@ -67,8 +67,14 @@ export class SpecificationFormComponent implements OnInit {
     // even though the file is no longer selected.
 
     this.modalService.open(content, {}).result.then(
-      () => {},
-      () => {}
+      () => {
+        // modal is closed
+        this.error = undefined;
+      },
+      () => {
+        // modal is dismissed
+        this.error = undefined;
+      }
       );
   }
 
@@ -119,6 +125,7 @@ export class SpecificationFormComponent implements OnInit {
 
     this.serviceStore.createSpecification(file)
       .subscribe(event => {
+          this.modalService.dismissAll();
           this.router.navigateByUrl('/');
         },
         error => this.error = error.error.userMessage);


### PR DESCRIPTION
Before, if an error prevented a file upload, the modal window would close, and the error message would be displayed in the body of the main page (above the buttons which open the file upload modals).

This change has the error appear inside the modal, and the modal remain open, making it simpler to adjust the form inputs so that the operation can eventually succeed.

<img width="960" alt="move-error" src="https://user-images.githubusercontent.com/6897716/60434162-d0e64700-9c06-11e9-84bc-0e9752c9dd61.PNG">

