### PR TITLE
Exception for malformed remote URL

### DIFF
--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
@@ -63,6 +63,10 @@ class RestResponseExceptionHandler {
 
     @ExceptionHandler(RemoteFileConnectionRefusedException::class)
     fun handleConnectionRefused(exception: RemoteFileConnectionRefusedException) =
-            makeResponseEntity("Specification couldn't be retrieved from ${exception.location}.", HttpStatus.NOT_FOUND)
+            makeResponseEntity("Specification couldn't be retrieved (HTTP Not found)", HttpStatus.NOT_FOUND)
+
+    @ExceptionHandler(BadUrlException::class)
+    fun handleMalformedUrl(exception: BadUrlException) =
+            makeResponseEntity("URL couldn't be parsed", HttpStatus.BAD_REQUEST)
 }
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationFileDownloader.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationFileDownloader.kt
@@ -1,11 +1,13 @@
 package com.tngtech.apicenter.backend.connector.rest.service
 
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileDto
+import com.tngtech.apicenter.backend.domain.exceptions.BadUrlException
 import com.tngtech.apicenter.backend.domain.exceptions.RemoteFileConnectionRefusedException
 import org.springframework.stereotype.Service
 import java.net.URL
 import java.util.Scanner
 import java.net.ConnectException
+import java.net.MalformedURLException
 
 @Service
 class SpecificationFileDownloader {
@@ -15,6 +17,8 @@ class SpecificationFileDownloader {
             Scanner(URL(location).openStream(), "UTF-8").useDelimiter("\\A").next()
         } catch (exception: ConnectException) {
             throw RemoteFileConnectionRefusedException(location)
+        } catch (exception: MalformedURLException) {
+            throw BadUrlException(location)
         }
 
     fun getLocalOrRemoteFileContent(specificationFileDto: SpecificationFileDto): String {

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/exceptions/Exceptions.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/exceptions/Exceptions.kt
@@ -8,3 +8,4 @@ class MismatchedServiceIdException(val userDefinedId: String, val urlPathId: Str
 class SpecificationDuplicationException: RuntimeException()
 class SpecificationConflictException: RuntimeException()
 class RemoteFileConnectionRefusedException(val location: String): RuntimeException()
+class BadUrlException(val location: String): RuntimeException()


### PR DESCRIPTION
Submitting something like "hello" to the remote file form causes an exception that wasn't part of the rest response exception handler, and so did not return an error message in a way the frontend could use:

`{"timestamp":1562056004073,"status":500,"error":"Internal Server Error","message":"no protocol: hello","path":"/api/v1/service"}`

This change also removes the string the user gave (ie. `location`) from the error message, because it already appears directly below in the form text box. (However it still might be useful for backend logging, so it's been left in the Exception constructors.)