### PR TITLE
Add ID to user defined metadata form

### DIFF
--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/RestResponseExceptionHandler.kt
@@ -49,8 +49,7 @@ class RestResponseExceptionHandler {
 
     @ExceptionHandler(MismatchedServiceIdException::class)
     fun handleServiceIdMismatch(exception: MismatchedServiceIdException) =
-            makeResponseEntity("The API ID used in the upload URL (${exception.urlPathId}) " +
-                    "is not the same as the API ID used in the specification body (${exception.userDefinedId})", HttpStatus.BAD_REQUEST)
+            makeResponseEntity("The supplied API IDs don't match", HttpStatus.BAD_REQUEST)
 
     @ExceptionHandler(SpecificationDuplicationException::class)
     fun handleSpecificationDuplication(exception: SpecificationDuplicationException) =

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
@@ -54,7 +54,7 @@ class ServiceController @Autowired constructor(
     private fun getConsistentId(specificationFileDto: SpecificationFileDto, specificationIdFromPath: String): String {
         specificationFileDto.id?.let {
             idFromFile -> if (idFromFile != specificationIdFromPath)
-                throw MismatchedServiceIdException(idFromFile, specificationIdFromPath)
+                throw MismatchedServiceIdException(listOf(idFromFile, specificationIdFromPath))
         }
         return specificationIdFromPath
     }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationFileDto.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/SpecificationFileDto.kt
@@ -8,6 +8,7 @@ data class SpecificationFileMetadata constructor(
     val version: String,
     val description: String?,
     val language: ApiLanguage,
+    val id: String?,
     val endpointUrl: String? = null
 )
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataParser.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataParser.kt
@@ -96,7 +96,8 @@ class SpecificationDataParser @Autowired constructor(
                                   metadata: SpecificationFileMetadata? = null
     ): SpecificationMetadata {
         val idFromUpload = extractId(fileContent)
-        val serviceId = getConsistentServiceId(idFromUpload, idFromPath)
+        val serviceId = getConsistentServiceId(listOf(idFromUpload, idFromPath, metadata?.id))
+
         val version = metadata?.version ?: extractVersion(fileContent)
         try {
             SemVer.valueOf(version)
@@ -126,10 +127,12 @@ class SpecificationDataParser @Autowired constructor(
 
     }
 
-    private fun getConsistentServiceId(idFromUpload: String?, idFromPath: String?): ServiceId {
-        if (idFromUpload != null && idFromPath != null && idFromUpload != idFromPath) {
-            throw MismatchedServiceIdException(idFromUpload, idFromPath)
+    private fun getConsistentServiceId(ids: List<String?>): ServiceId {
+        val notNullIds: List<String> = ids.filterNotNull()
+        if (notNullIds.distinct().size > 1) {
+            throw MismatchedServiceIdException(notNullIds)
         }
-        return ServiceId(idFromUpload ?: idFromPath ?: UUID.randomUUID().toString())
+
+        return ServiceId(ids.first() ?: UUID.randomUUID().toString())
     }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataParser.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/service/SpecificationDataParser.kt
@@ -133,6 +133,6 @@ class SpecificationDataParser @Autowired constructor(
             throw MismatchedServiceIdException(notNullIds)
         }
 
-        return ServiceId(ids.first() ?: UUID.randomUUID().toString())
+        return ServiceId(notNullIds.firstOrNull() ?: UUID.randomUUID().toString())
     }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/exceptions/Exceptions.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/exceptions/Exceptions.kt
@@ -4,7 +4,7 @@ class SpecificationNotFoundException(val serviceId: String, val version: String?
 class SpecificationParseException(val userMessage: String) : RuntimeException()
 class SpecificationAlreadyExistsException(val title: String) : RuntimeException()
 class InvalidServiceIdException(val userDefinedId: String): RuntimeException()
-class MismatchedServiceIdException(val userDefinedId: String, val urlPathId: String): RuntimeException()
+class MismatchedServiceIdException(val ids: List<String>): RuntimeException()
 class SpecificationDuplicationException: RuntimeException()
 class SpecificationConflictException: RuntimeException()
 class RemoteFileConnectionRefusedException(val location: String): RuntimeException()

--- a/frontend/src/app/models/specificationfile.ts
+++ b/frontend/src/app/models/specificationfile.ts
@@ -5,6 +5,7 @@ export interface SpecificationMetadata {
   version: string;
   description: string;
   language: ApiLanguage;
+  apiId: string;
   endpointUrl: string;
 }
 

--- a/frontend/src/app/models/specificationfile.ts
+++ b/frontend/src/app/models/specificationfile.ts
@@ -5,7 +5,7 @@ export interface SpecificationMetadata {
   version: string;
   description: string;
   language: ApiLanguage;
-  apiId: string;
+  id: string;
   endpointUrl: string;
 }
 

--- a/frontend/src/app/models/specificationfile.ts
+++ b/frontend/src/app/models/specificationfile.ts
@@ -3,10 +3,10 @@ import {ApiLanguage} from './specification';
 export interface SpecificationMetadata {
   title: string;
   version: string;
-  description: string;
+  description?: string;
   language: ApiLanguage;
-  id: string;
-  endpointUrl: string;
+  id?: string;
+  endpointUrl?: string;
 }
 
 export class SpecificationFile {

--- a/frontend/src/app/specification-form/specification-form.component.html
+++ b/frontend/src/app/specification-form/specification-form.component.html
@@ -21,14 +21,21 @@
          <p>
            For a GraphQL specification, ApiCenter needs some additional metadata:
          </p>
-         <div *ngFor="let fieldName of objectKeys(additionalFields)">
+         <div *ngFor="let fieldName of objectKeys({
+                                          title: additionalFields.title,
+                                          version: additionalFields.version,
+                                          description: additionalFields.description
+                                          })">
            <input type="text"
                   [placeholder]="fieldName.charAt(0).toUpperCase() + fieldName.slice(1)"
                   [(ngModel)]="additionalFields[fieldName]"/>
          </div>
          <hr>
          <p>Test API endpoint, where sample requests can be sent:</p>
-         <input type="text" placeholder="URL" [(ngModel)]="endpointUrl"/>
+         <input type="text" placeholder="URL" [(ngModel)]="additionalFields.endpointUrl"/>
+         <hr>
+         <p>(Optional) A unique id to be associated with this specification, so that subsequent version uploads will appear together in the overview</p>
+         <input type="text" placeholder="ID" [(ngModel)]="additionalFields.apiId"/>
        </div>
     </div>
 

--- a/frontend/src/app/specification-form/specification-form.component.html
+++ b/frontend/src/app/specification-form/specification-form.component.html
@@ -35,7 +35,7 @@
          <input type="text" placeholder="URL" [(ngModel)]="additionalFields.endpointUrl"/>
          <hr>
          <p>(Optional) A unique id to be associated with this specification, so that subsequent version uploads will appear together in the overview</p>
-         <input type="text" placeholder="ID" [(ngModel)]="additionalFields.apiId"/>
+         <input type="text" placeholder="ID" [(ngModel)]="additionalFields.id"/>
        </div>
     </div>
 

--- a/frontend/src/app/specification-form/specification-form.component.ts
+++ b/frontend/src/app/specification-form/specification-form.component.ts
@@ -40,8 +40,7 @@ export class SpecificationFormComponent implements OnInit {
   error: string;
   specificationFile: File;
   remoteFileUrl: string;
-  additionalFields = {title: '', version: '', description: ''};
-  endpointUrl = '';
+  additionalFields = {title: '', version: '', description: '', endpointUrl: '', apiId: ''};
   isGraphQLFile = false;
   objectKeys = Object.keys;
 
@@ -118,9 +117,8 @@ export class SpecificationFormComponent implements OnInit {
   }
 
   private createSpecification(fileContent: string, fileUrl: string) {
-    const endpointUrl = this.endpointUrl;
     const metadata: SpecificationMetadata = this.isGraphQLFile ?
-      {...this.additionalFields, language: ApiLanguage.GraphQL, endpointUrl} : null;
+      {...this.additionalFields, language: ApiLanguage.GraphQL} : null;
     const file = new SpecificationFile(fileContent, fileUrl, metadata);
 
     this.serviceStore.createSpecification(file)

--- a/frontend/src/app/specification-form/specification-form.component.ts
+++ b/frontend/src/app/specification-form/specification-form.component.ts
@@ -40,7 +40,7 @@ export class SpecificationFormComponent implements OnInit {
   error: string;
   specificationFile: File;
   remoteFileUrl: string;
-  additionalFields = {title: '', version: '', description: '', endpointUrl: '', apiId: ''};
+  additionalFields = {title: '', version: '', description: '', endpointUrl: '', id: ''};
   isGraphQLFile = false;
   objectKeys = Object.keys;
 
@@ -51,13 +51,6 @@ export class SpecificationFormComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.route.params.subscribe(params => {
-      if (params['id']) {
-        this.serviceStore.getService(params['id']).subscribe((service: Service) => {
-          this.remoteFileUrl = service.remoteAddress;
-        });
-      }
-    });
   }
 
   private open(content) {


### PR DESCRIPTION
Add ID as a field (like title/version) when inputting metadata for files which don't provide it in their contents (ie. GraphQL). Because of this, previously there was no way (through the frontend) to associate a new version with a pre-existing service.

Also, since deleting the "edit-specification"/pencil button in the overview a while ago, there is no longer a route to `/add-specifications/:id`, hence the body of the `ngInit` is deleted.

Maybe the "edit-specification" button should make a return? Otherwise it is not possible through the frontend to add a new version of an OpenAPI service which doesn't have an `x-api-id`. Or is that a good thing?