### PR TITLE
Pagination in specification overview

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.springframework.boot:spring-boot-starter-web:$spring_boot_version"
     compile "org.springframework.boot:spring-boot-starter-security:$spring_boot_version"
+    compile "org.springframework.boot:spring-boot-configuration-processor:$spring_boot_version"
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.springframework.boot:spring-boot-starter-data-jpa:$spring_boot_version"
     compile "org.postgresql:postgresql:42.2.6"

--- a/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerIntegrationTest.kt
+++ b/backend/src/integration-test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerIntegrationTest.kt
@@ -25,17 +25,17 @@ internal class ServiceControllerIntegrationTest {
 
     @Test
     fun findAllServices_shouldReturnAllServices() {
-        mockMvc.perform(get("/api/v1/service").with(user("user")))
+        mockMvc.perform(get("/api/v1/service?page=0").with(user("user")))
             .andExpect(status().isOk)
             .andExpect(content().contentType("application/json;charset=UTF-8"))
-            .andExpect(jsonPath("$[0].title", equalTo("Spec1")))
-            .andExpect(jsonPath("$[0].specifications[0].metadata.version", equalTo("1.0.0")))
-            .andExpect(jsonPath("$[1].title", equalTo("Spec2")))
-            .andExpect(jsonPath("$[1].specifications[0].metadata.version", equalTo("1.0.0")))
-            .andExpect(jsonPath("$[1].specifications[1].metadata.version", equalTo("2.0.0")))
-            .andExpect(jsonPath("$[2].title", equalTo("Spec3")))
-            .andExpect(jsonPath("$[2].specifications[0].metadata.version", equalTo("1.0.0")))
-            .andExpect(jsonPath("$[2].specifications[1].metadata.version", equalTo("1.1.0")))
+            .andExpect(jsonPath("$.content[0].title", equalTo("Spec1")))
+            .andExpect(jsonPath("$.content[0].specifications[0].metadata.version", equalTo("1.0.0")))
+            .andExpect(jsonPath("$.content[1].title", equalTo("Spec2")))
+            .andExpect(jsonPath("$.content[1].specifications[0].metadata.version", equalTo("1.0.0")))
+            .andExpect(jsonPath("$.content[1].specifications[1].metadata.version", equalTo("2.0.0")))
+            .andExpect(jsonPath("$.content[2].title", equalTo("Spec3")))
+            .andExpect(jsonPath("$.content[2].specifications[0].metadata.version", equalTo("1.0.0")))
+            .andExpect(jsonPath("$.content[2].specifications[1].metadata.version", equalTo("1.1.0")))
     }
 
     @Test

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/ApiCenterProperties.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/ApiCenterProperties.kt
@@ -4,5 +4,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("apicenter")
 class ApiCenterProperties{
-    val pageSize = 10
+    private var pageSize = 10
+
+    fun getPageSize(): Int = pageSize
+
+    fun setPageSize(newPageSize: Int) {
+        pageSize = newPageSize
+    }
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/ApiCenterProperties.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/ApiCenterProperties.kt
@@ -1,0 +1,8 @@
+package com.tngtech.apicenter.backend.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("apicenter")
+class ApiCenterProperties{
+    val pageSize = 10
+}

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/Configuration.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/config/Configuration.kt
@@ -3,10 +3,12 @@ package com.tngtech.apicenter.backend.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
+@EnableConfigurationProperties(ApiCenterProperties::class)
 class Configuration {
 
     @Bean

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/repository/ServiceRepository.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/repository/ServiceRepository.kt
@@ -2,11 +2,12 @@ package com.tngtech.apicenter.backend.connector.database.repository
 
 import com.tngtech.apicenter.backend.connector.database.entity.ServiceEntity
 import org.springframework.data.repository.CrudRepository
+import org.springframework.data.repository.PagingAndSortingRepository
 import org.springframework.stereotype.Repository
 import java.util.*
 
 @Repository
-interface ServiceRepository : CrudRepository<ServiceEntity, String> {
+interface ServiceRepository : PagingAndSortingRepository<ServiceEntity, String> {
 
     override fun existsById(id: String): Boolean
     override fun findById(id: String): Optional<ServiceEntity>

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/ServiceDatabase.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/ServiceDatabase.kt
@@ -3,6 +3,7 @@ package com.tngtech.apicenter.backend.connector.database.service
 import com.tngtech.apicenter.backend.connector.database.entity.ServiceEntity
 import com.tngtech.apicenter.backend.connector.database.mapper.ServiceEntityMapper
 import com.tngtech.apicenter.backend.connector.database.repository.ServiceRepository
+import com.tngtech.apicenter.backend.domain.entity.ResultPage
 import com.tngtech.apicenter.backend.domain.entity.Service
 import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.exceptions.SpecificationAlreadyExistsException
@@ -10,8 +11,7 @@ import com.tngtech.apicenter.backend.domain.service.ServicePersistor
 import org.hibernate.search.exception.EmptyQueryException
 import org.hibernate.search.jpa.Search
 import org.springframework.dao.DataIntegrityViolationException
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.PageRequest
 import javax.persistence.EntityManager
 import javax.transaction.Transactional
 
@@ -33,8 +33,11 @@ class ServiceDatabase constructor(
         }
     }
 
-    override fun findAll(pageable: Pageable): Page<Service> =
-        serviceRepository.findAll(pageable).map { spec -> serviceEntityMapper.toDomain(spec) }
+    override fun findAll(pageNumber: Int, pageSize: Int): ResultPage<Service> {
+        val pageable = PageRequest.of(pageNumber, pageSize)
+        val page = serviceRepository.findAll(pageable).map { spec -> serviceEntityMapper.toDomain(spec) }
+        return ResultPage(page.content, page.isLast)
+    }
 
     override fun findOne(id: ServiceId): Service? =
         serviceRepository.findById(id.id).orElse(null)?.let { spec -> serviceEntityMapper.toDomain(spec) }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/ServiceDatabase.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/ServiceDatabase.kt
@@ -10,8 +10,13 @@ import com.tngtech.apicenter.backend.domain.service.ServicePersistor
 import org.hibernate.search.exception.EmptyQueryException
 import org.hibernate.search.jpa.Search
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import javax.persistence.EntityManager
 import javax.transaction.Transactional
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {  }
 
 @org.springframework.stereotype.Service
 class ServiceDatabase constructor(
@@ -31,7 +36,11 @@ class ServiceDatabase constructor(
         }
     }
 
-    override fun findAll(): List<Service> = serviceRepository.findAll().map { spec -> serviceEntityMapper.toDomain(spec) }
+    override fun findAll(pageable: Pageable): Page<Service> {
+        val page = serviceRepository.findAll(pageable)
+        logger.info(page.toString())
+        return page.map { spec -> serviceEntityMapper.toDomain(spec) }
+    }
 
     override fun findOne(id: ServiceId): Service? =
         serviceRepository.findById(id.id).orElse(null)?.let { spec -> serviceEntityMapper.toDomain(spec) }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/ServiceDatabase.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/database/service/ServiceDatabase.kt
@@ -14,9 +14,6 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import javax.persistence.EntityManager
 import javax.transaction.Transactional
-import mu.KotlinLogging
-
-private val logger = KotlinLogging.logger {  }
 
 @org.springframework.stereotype.Service
 class ServiceDatabase constructor(
@@ -36,11 +33,8 @@ class ServiceDatabase constructor(
         }
     }
 
-    override fun findAll(pageable: Pageable): Page<Service> {
-        val page = serviceRepository.findAll(pageable)
-        logger.info(page.toString())
-        return page.map { spec -> serviceEntityMapper.toDomain(spec) }
-    }
+    override fun findAll(pageable: Pageable): Page<Service> =
+        serviceRepository.findAll(pageable).map { spec -> serviceEntityMapper.toDomain(spec) }
 
     override fun findOne(id: ServiceId): Service? =
         serviceRepository.findById(id.id).orElse(null)?.let { spec -> serviceEntityMapper.toDomain(spec) }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
@@ -1,12 +1,12 @@
 package com.tngtech.apicenter.backend.connector.rest.controller
 
+import com.tngtech.apicenter.backend.connector.rest.dto.ResultPageDto
 import com.tngtech.apicenter.backend.connector.rest.dto.ServiceDto
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationDto
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileDto
 import com.tngtech.apicenter.backend.connector.rest.mapper.ServiceDtoMapper
 import com.tngtech.apicenter.backend.connector.rest.mapper.SpecificationFileDtoMapper
 import com.tngtech.apicenter.backend.connector.rest.service.RemoteServiceUpdater
-import com.tngtech.apicenter.backend.domain.entity.ResultPage
 import com.tngtech.apicenter.backend.domain.exceptions.SpecificationNotFoundException
 import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Specification
@@ -63,9 +63,10 @@ class ServiceController @Autowired constructor(
     }
 
     @GetMapping(params = ["page"])
-    fun findAllServices(@RequestParam(value = "page", defaultValue = "0") page: String): ResultPage<ServiceDto> =
+    fun findAllServices(@RequestParam(value = "page") page: String): ResultPageDto<ServiceDto> =
         try {
-            serviceHandler.findAll(page.toInt(), 10).map { service -> serviceDtoMapper.fromDomain(service) }
+            val resultPage = serviceHandler.findAll(page.toInt(), 10).map { service -> serviceDtoMapper.fromDomain(service) }
+            ResultPageDto(resultPage.content, resultPage.last)
         } catch (exception: NumberFormatException) {
             throw BadUrlException(page)
         }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
@@ -6,6 +6,7 @@ import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileDto
 import com.tngtech.apicenter.backend.connector.rest.mapper.ServiceDtoMapper
 import com.tngtech.apicenter.backend.connector.rest.mapper.SpecificationFileDtoMapper
 import com.tngtech.apicenter.backend.connector.rest.service.RemoteServiceUpdater
+import com.tngtech.apicenter.backend.domain.entity.ResultPage
 import com.tngtech.apicenter.backend.domain.exceptions.SpecificationNotFoundException
 import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Specification
@@ -13,8 +14,6 @@ import com.tngtech.apicenter.backend.domain.exceptions.BadUrlException
 import com.tngtech.apicenter.backend.domain.exceptions.MismatchedServiceIdException
 import com.tngtech.apicenter.backend.domain.handler.ServiceHandler
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
@@ -64,9 +63,9 @@ class ServiceController @Autowired constructor(
     }
 
     @GetMapping(params = ["page"])
-    fun findAllServices(@RequestParam("page") page: String): Page<ServiceDto> =
+    fun findAllServices(@RequestParam(value = "page", defaultValue = "0") page: String): ResultPage<ServiceDto> =
         try {
-            serviceHandler.findAll(PageRequest.of(page.toInt(), 10)).map { service -> serviceDtoMapper.fromDomain(service) }
+            serviceHandler.findAll(page.toInt(), 10).map { service -> serviceDtoMapper.fromDomain(service) }
         } catch (exception: NumberFormatException) {
             throw BadUrlException(page)
         }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
@@ -67,7 +67,7 @@ class ServiceController @Autowired constructor(
     @GetMapping(params = ["page"])
     fun findAllServices(@RequestParam(value = "page") page: String): ResultPageDto<ServiceDto> =
         try {
-            val resultPage = serviceHandler.findAll(page.toInt(), apiCenterProperties.pageSize).map { service -> serviceDtoMapper.fromDomain(service) }
+            val resultPage = serviceHandler.findAll(page.toInt(), apiCenterProperties.getPageSize()).map { service -> serviceDtoMapper.fromDomain(service) }
             ResultPageDto(resultPage.content, resultPage.last)
         } catch (exception: NumberFormatException) {
             throw BadUrlException(page)

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
@@ -12,8 +12,14 @@ import com.tngtech.apicenter.backend.domain.entity.Specification
 import com.tngtech.apicenter.backend.domain.exceptions.MismatchedServiceIdException
 import com.tngtech.apicenter.backend.domain.handler.ServiceHandler
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
+import mu.KotlinLogging
+
+private val logger = KotlinLogging.logger {  }
 
 @RestController
 @RequestMapping("/api/v1/service")
@@ -61,8 +67,12 @@ class ServiceController @Autowired constructor(
     }
 
     @GetMapping
-    fun findAllServices(): List<ServiceDto> =
-        serviceHandler.findAll().map { service -> serviceDtoMapper.fromDomain(service) }
+    fun findAllServices(): Page<ServiceDto> {
+        val page = serviceHandler.findAll(PageRequest.of(0, 10))
+        logger.info(page.toString())
+        logger.info(page.content.toString())
+        return page.map { service -> serviceDtoMapper.fromDomain(service) }
+    }
 
     @GetMapping("/{serviceId}")
     fun findService(@PathVariable serviceId: String): ServiceDto {

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
@@ -14,12 +14,8 @@ import com.tngtech.apicenter.backend.domain.handler.ServiceHandler
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
-import mu.KotlinLogging
-
-private val logger = KotlinLogging.logger {  }
 
 @RestController
 @RequestMapping("/api/v1/service")
@@ -67,12 +63,8 @@ class ServiceController @Autowired constructor(
     }
 
     @GetMapping
-    fun findAllServices(): Page<ServiceDto> {
-        val page = serviceHandler.findAll(PageRequest.of(0, 10))
-        logger.info(page.toString())
-        logger.info(page.content.toString())
-        return page.map { service -> serviceDtoMapper.fromDomain(service) }
-    }
+    fun findAllServices(): Page<ServiceDto> =
+        serviceHandler.findAll(PageRequest.of(0, 10)).map { service -> serviceDtoMapper.fromDomain(service) }
 
     @GetMapping("/{serviceId}")
     fun findService(@PathVariable serviceId: String): ServiceDto {

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
@@ -28,6 +28,7 @@ class ServiceController @Autowired constructor(
         private val specificationFileDtoMapper: SpecificationFileDtoMapper,
         private val serviceDtoMapper: ServiceDtoMapper
 ) {
+
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun uploadSpecifications(@RequestBody specificationFileDtos: List<SpecificationFileDto>): List<Specification> {

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
@@ -66,7 +66,7 @@ class ServiceController @Autowired constructor(
     @GetMapping(params = ["page"])
     fun findAllServices(@RequestParam("page") page: String): Page<ServiceDto> =
         try {
-            serviceHandler.findAll(PageRequest.of(page.toInt(), 1)).map { service -> serviceDtoMapper.fromDomain(service) }
+            serviceHandler.findAll(PageRequest.of(page.toInt(), 10)).map { service -> serviceDtoMapper.fromDomain(service) }
         } catch (exception: NumberFormatException) {
             throw BadUrlException(page)
         }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
@@ -16,7 +16,9 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
+import mu.KotlinLogging
 
+private val logger = KotlinLogging.logger {  }
 @RestController
 @RequestMapping("/api/v1/service")
 class ServiceController @Autowired constructor(
@@ -62,9 +64,12 @@ class ServiceController @Autowired constructor(
         return specificationIdFromPath
     }
 
-    @GetMapping
-    fun findAllServices(): Page<ServiceDto> =
-        serviceHandler.findAll(PageRequest.of(0, 10)).map { service -> serviceDtoMapper.fromDomain(service) }
+    @GetMapping(params = ["page"])
+    fun findAllServices(@RequestParam("page") page: String): Page<ServiceDto> {
+
+        logger.info(page)
+        return serviceHandler.findAll(PageRequest.of(page.toInt(), 1)).map { service -> serviceDtoMapper.fromDomain(service) }
+    }
 
     @GetMapping("/{serviceId}")
     fun findService(@PathVariable serviceId: String): ServiceDto {

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
@@ -14,6 +14,7 @@ import com.tngtech.apicenter.backend.domain.exceptions.BadUrlException
 import com.tngtech.apicenter.backend.domain.exceptions.MismatchedServiceIdException
 import com.tngtech.apicenter.backend.domain.handler.ServiceHandler
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
@@ -25,6 +26,9 @@ class ServiceController @Autowired constructor(
         private val specificationFileDtoMapper: SpecificationFileDtoMapper,
         private val serviceDtoMapper: ServiceDtoMapper
 ) {
+
+    @Value("\${page-size:10}")
+    private lateinit var pageSize: Int
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -65,7 +69,7 @@ class ServiceController @Autowired constructor(
     @GetMapping(params = ["page"])
     fun findAllServices(@RequestParam(value = "page") page: String): ResultPageDto<ServiceDto> =
         try {
-            val resultPage = serviceHandler.findAll(page.toInt(), 10).map { service -> serviceDtoMapper.fromDomain(service) }
+            val resultPage = serviceHandler.findAll(page.toInt(), pageSize).map { service -> serviceDtoMapper.fromDomain(service) }
             ResultPageDto(resultPage.content, resultPage.last)
         } catch (exception: NumberFormatException) {
             throw BadUrlException(page)

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceController.kt
@@ -1,5 +1,6 @@
 package com.tngtech.apicenter.backend.connector.rest.controller
 
+import com.tngtech.apicenter.backend.config.ApiCenterProperties
 import com.tngtech.apicenter.backend.connector.rest.dto.ResultPageDto
 import com.tngtech.apicenter.backend.connector.rest.dto.ServiceDto
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationDto
@@ -21,15 +22,12 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/v1/service")
 class ServiceController @Autowired constructor(
+        private val apiCenterProperties: ApiCenterProperties,
         private val serviceHandler: ServiceHandler,
         private val remoteServiceUpdater: RemoteServiceUpdater,
         private val specificationFileDtoMapper: SpecificationFileDtoMapper,
         private val serviceDtoMapper: ServiceDtoMapper
 ) {
-
-    @Value("\${page-size:10}")
-    private lateinit var pageSize: Int
-
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     fun uploadSpecifications(@RequestBody specificationFileDtos: List<SpecificationFileDto>): List<Specification> {
@@ -69,7 +67,7 @@ class ServiceController @Autowired constructor(
     @GetMapping(params = ["page"])
     fun findAllServices(@RequestParam(value = "page") page: String): ResultPageDto<ServiceDto> =
         try {
-            val resultPage = serviceHandler.findAll(page.toInt(), pageSize).map { service -> serviceDtoMapper.fromDomain(service) }
+            val resultPage = serviceHandler.findAll(page.toInt(), apiCenterProperties.pageSize).map { service -> serviceDtoMapper.fromDomain(service) }
             ResultPageDto(resultPage.content, resultPage.last)
         } catch (exception: NumberFormatException) {
             throw BadUrlException(page)

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/ResultPageDto.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/connector/rest/dto/ResultPageDto.kt
@@ -1,0 +1,6 @@
+package com.tngtech.apicenter.backend.connector.rest.dto
+
+data class ResultPageDto<T> constructor(
+        val content: List<T>,
+        val last: Boolean
+)

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/ResultPage.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/ResultPage.kt
@@ -1,0 +1,9 @@
+package com.tngtech.apicenter.backend.domain.entity
+
+class ResultPage<T> constructor(
+        val content: List<T>,
+        val isLast: Boolean
+) {
+    fun <U> map(callback: (element: T) -> U): ResultPage<U> =
+            ResultPage(this.content.map(callback), this.isLast)
+}

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/ResultPage.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/entity/ResultPage.kt
@@ -2,8 +2,8 @@ package com.tngtech.apicenter.backend.domain.entity
 
 class ResultPage<T> constructor(
         val content: List<T>,
-        val isLast: Boolean
+        val last: Boolean
 ) {
     fun <U> map(callback: (element: T) -> U): ResultPage<U> =
-            ResultPage(this.content.map(callback), this.isLast)
+            ResultPage(this.content.map(callback), this.last)
 }

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/handler/ServiceHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/handler/ServiceHandler.kt
@@ -8,6 +8,8 @@ import com.tngtech.apicenter.backend.domain.exceptions.SpecificationConflictExce
 import com.tngtech.apicenter.backend.domain.exceptions.SpecificationDuplicationException
 import com.tngtech.apicenter.backend.domain.service.ServicePersistor
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 
 @Component
@@ -60,7 +62,7 @@ class ServiceHandler @Autowired constructor(
 
     }
 
-    fun findAll(): List<Service> = servicePersistor.findAll()
+    fun findAll(pageable: Pageable): Page<Service> = servicePersistor.findAll(pageable)
 
     fun findOne(id: ServiceId): Service? = servicePersistor.findOne(id)
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/handler/ServiceHandler.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/handler/ServiceHandler.kt
@@ -1,6 +1,7 @@
 package com.tngtech.apicenter.backend.domain.handler
 
 import com.tngtech.apicenter.backend.domain.entity.ReleaseType
+import com.tngtech.apicenter.backend.domain.entity.ResultPage
 import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Service
 import com.tngtech.apicenter.backend.domain.entity.Specification
@@ -8,8 +9,6 @@ import com.tngtech.apicenter.backend.domain.exceptions.SpecificationConflictExce
 import com.tngtech.apicenter.backend.domain.exceptions.SpecificationDuplicationException
 import com.tngtech.apicenter.backend.domain.service.ServicePersistor
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 
 @Component
@@ -62,7 +61,8 @@ class ServiceHandler @Autowired constructor(
 
     }
 
-    fun findAll(pageable: Pageable): Page<Service> = servicePersistor.findAll(pageable)
+    fun findAll(pageNumber: Int, pageSize: Int): ResultPage<Service> =
+            servicePersistor.findAll(pageNumber, pageSize)
 
     fun findOne(id: ServiceId): Service? = servicePersistor.findOne(id)
 

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/service/ServicePersistor.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/service/ServicePersistor.kt
@@ -2,10 +2,12 @@ package com.tngtech.apicenter.backend.domain.service
 
 import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Service
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 
 interface ServicePersistor {
     fun save(service: Service)
-    fun findAll(): List<Service>
+    fun findAll(pageable: Pageable): Page<Service>
     fun findOne(id: ServiceId): Service?
     fun delete(id: ServiceId)
     fun exists(id: ServiceId): Boolean

--- a/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/service/ServicePersistor.kt
+++ b/backend/src/main/kotlin/com/tngtech/apicenter/backend/domain/service/ServicePersistor.kt
@@ -1,13 +1,12 @@
 package com.tngtech.apicenter.backend.domain.service
 
+import com.tngtech.apicenter.backend.domain.entity.ResultPage
 import com.tngtech.apicenter.backend.domain.entity.ServiceId
 import com.tngtech.apicenter.backend.domain.entity.Service
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 
 interface ServicePersistor {
     fun save(service: Service)
-    fun findAll(pageable: Pageable): Page<Service>
+    fun findAll(pageNumber: Int, pageSize: Int): ResultPage<Service>
     fun findOne(id: ServiceId): Service?
     fun delete(id: ServiceId)
     fun exists(id: ServiceId): Boolean

--- a/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/backend/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,8 @@
+{
+  "properties": [
+    {
+      "name": "apicenter.pageSize",
+      "type": "java.lang.Integer",
+      "description": "Number of services to be fetched per page in specification overview."
+  }
+] }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,3 +4,5 @@ spring.flyway.baseline-on-migrate = true
 
 spring.jpa.hibernate.ddl-auto = update
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
+
+page-size=10

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,3 +4,5 @@ spring.flyway.baseline-on-migrate = true
 
 spring.jpa.hibernate.ddl-auto = update
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
+
+apicenter.pageSize=1

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,5 +4,3 @@ spring.flyway.baseline-on-migrate = true
 
 spring.jpa.hibernate.ddl-auto = update
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
-
-apicenter.pageSize=1

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -4,5 +4,3 @@ spring.flyway.baseline-on-migrate = true
 
 spring.jpa.hibernate.ddl-auto = update
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
-
-page-size=10

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerUnitTest.kt
@@ -12,6 +12,8 @@ import com.tngtech.apicenter.backend.domain.entity.*
 import com.tngtech.apicenter.backend.domain.handler.ServiceHandler
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import java.util.*
 
 internal class ServiceControllerUnitTest {
@@ -81,10 +83,11 @@ internal class ServiceControllerUnitTest {
             "http://swaggerpetstore.com/docs"
         )
 
-        given(serviceHandler.findAll()).willReturn(arrayListOf(service))
+        val request = PageRequest.of(0, 10)
+        given(serviceHandler.findAll(request)).willReturn(PageImpl<Service>(listOf(service)))
         given(serviceDtoMapper.fromDomain(service)).willReturn(serviceDto)
 
-        assertThat(serviceController.findAllServices()).containsOnly(
+        assertThat(serviceController.findAllServices("0")).containsOnly(
             ServiceDto(
                 uuid, "Test",
                 "Description",

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerUnitTest.kt
@@ -2,6 +2,7 @@ package com.tngtech.apicenter.backend.connector.rest.controller
 
 import com.nhaarman.mockitokotlin2.given
 import com.nhaarman.mockitokotlin2.mock
+import com.tngtech.apicenter.backend.config.ApiCenterProperties
 import com.tngtech.apicenter.backend.connector.rest.dto.ServiceDto
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationFileDto
 import com.tngtech.apicenter.backend.connector.rest.dto.SpecificationDto
@@ -12,8 +13,6 @@ import com.tngtech.apicenter.backend.domain.entity.*
 import com.tngtech.apicenter.backend.domain.handler.ServiceHandler
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.springframework.data.domain.PageImpl
-import org.springframework.data.domain.PageRequest
 import java.util.*
 
 internal class ServiceControllerUnitTest {
@@ -35,6 +34,7 @@ internal class ServiceControllerUnitTest {
 
     private val serviceController: ServiceController =
         ServiceController(
+            ApiCenterProperties(),
             serviceHandler,
             remoteServiceUpdater,
             specificationFileDtoMapper,

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/rest/controller/ServiceControllerUnitTest.kt
@@ -83,11 +83,10 @@ internal class ServiceControllerUnitTest {
             "http://swaggerpetstore.com/docs"
         )
 
-        val request = PageRequest.of(0, 10)
-        given(serviceHandler.findAll(request)).willReturn(PageImpl<Service>(listOf(service)))
+        given(serviceHandler.findAll(0, 10)).willReturn(ResultPage(listOf(service), true))
         given(serviceDtoMapper.fromDomain(service)).willReturn(serviceDto)
 
-        assertThat(serviceController.findAllServices("0")).containsOnly(
+        assertThat(serviceController.findAllServices("0").content).containsOnly(
             ServiceDto(
                 uuid, "Test",
                 "Description",

--- a/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/service/ServiceDatabaseUnitTest.kt
+++ b/backend/src/test/kotlin/com/tngtech/apicenter/backend/connector/service/ServiceDatabaseUnitTest.kt
@@ -29,12 +29,6 @@ internal class ServiceDatabaseUnitTest {
     private val id = "e33dc111-3dd6-40f4-9c54-a64f6b10ab49"
 
     @Test
-    fun findAll_shouldReturnObjects() {
-        serviceDatabase.findAll()
-        verify(serviceRepository).findAll()
-    }
-
-    @Test
     fun delete_shouldDeleteObject() {
         val uuid = ServiceId(UUID.randomUUID().toString())
 

--- a/frontend/src/app/models/service.ts
+++ b/frontend/src/app/models/service.ts
@@ -22,36 +22,7 @@ export class Service {
   }
 }
 
-export interface PageOfServices {
-  services: Service[];
-  isLast: boolean;
-}
-
-export interface Page<T> {
-  // org.springframework.data.domain.Page
-
+export interface ResultPage<T> {
   content: T[];
-  pageable: {
-    sort: Sort;
-    offset: number;
-    pageNumber: number;
-    pageSize: number;
-    paged: boolean;
-    unpaged: boolean;
-  };
-  totalPages: number;
-  totalElements: number;
   last: boolean;
-  size: number;
-  number: number;
-  sort: Sort;
-  numberOfElements: number;
-  first: boolean;
-  empty: boolean;
-}
-
-interface Sort {
-  unsorted: boolean;
-  sorted: boolean;
-  empty: boolean;
 }

--- a/frontend/src/app/models/service.ts
+++ b/frontend/src/app/models/service.ts
@@ -21,3 +21,32 @@ export class Service {
       -compareVersions(spec1.metadata.version, spec2.metadata.version));
   }
 }
+
+export interface Page<T> {
+  // org.springframework.data.domain.Page
+
+  content: T[];
+  pageable: {
+    sort: Sort;
+    offset: number;
+    pageNumber: number;
+    pageSize: number;
+    paged: boolean;
+    unpaged: boolean;
+  };
+  totalPages: number;
+  totalElements: number;
+  last: boolean;
+  size: number;
+  number: number;
+  sort: Sort;
+  numberOfElements: number;
+  first: boolean;
+  empty: boolean;
+}
+
+interface Sort {
+  unsorted: boolean;
+  sorted: boolean;
+  empty: boolean;
+}

--- a/frontend/src/app/models/service.ts
+++ b/frontend/src/app/models/service.ts
@@ -22,6 +22,11 @@ export class Service {
   }
 }
 
+export interface PageOfServices {
+  services: Service[];
+  isLast: boolean;
+}
+
 export interface Page<T> {
   // org.springframework.data.domain.Page
 

--- a/frontend/src/app/service-store.service.ts
+++ b/frontend/src/app/service-store.service.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {HttpClient} from '@angular/common/http';
+import {HttpClient, HttpParams} from '@angular/common/http';
 import {environment} from '../environments/environment';
 import {Page, Service} from './models/service';
 import {SpecificationFile} from './models/specificationfile';
@@ -16,8 +16,10 @@ export class ServiceStore {
   constructor(private http: HttpClient) {
   }
 
-  public getServices(): Observable<Page<Service>> {
-    return this.http.get<Page<Service>>(this.urlRoot)
+  public getPage(pageNumber: number): Observable<Page<Service>> {
+    const params = new HttpParams().set("page", pageNumber.toString());
+    console.log("call");
+    return this.http.get<Page<Service>>(this.urlRoot, {params: params})
       .catch((error: any) => throwError(error || 'Server error'));
   }
 

--- a/frontend/src/app/service-store.service.ts
+++ b/frontend/src/app/service-store.service.ts
@@ -17,7 +17,7 @@ export class ServiceStore {
   }
 
   public getPage(pageNumber: number): Observable<Page<Service>> {
-    const params = new HttpParams().set("page", pageNumber.toString());
+    const params = new HttpParams().set('page', pageNumber.toString());
     return this.http.get<Page<Service>>(this.urlRoot, {params: params})
       .catch((error: any) => throwError(error || 'Server error'));
   }

--- a/frontend/src/app/service-store.service.ts
+++ b/frontend/src/app/service-store.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {HttpClient, HttpParams} from '@angular/common/http';
 import {environment} from '../environments/environment';
-import {Page, Service} from './models/service';
+import {ResultPage, Service} from './models/service';
 import {SpecificationFile} from './models/specificationfile';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/catch';
@@ -16,9 +16,9 @@ export class ServiceStore {
   constructor(private http: HttpClient) {
   }
 
-  public getPage(pageNumber: number): Observable<Page<Service>> {
+  public getPage(pageNumber: number): Observable<ResultPage<Service>> {
     const params = new HttpParams().set('page', pageNumber.toString());
-    return this.http.get<Page<Service>>(this.urlRoot, {params: params})
+    return this.http.get<ResultPage<Service>>(this.urlRoot, {params: params})
       .catch((error: any) => throwError(error || 'Server error'));
   }
 

--- a/frontend/src/app/service-store.service.ts
+++ b/frontend/src/app/service-store.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {environment} from '../environments/environment';
-import {Service} from './models/service';
+import {Page, Service} from './models/service';
 import {SpecificationFile} from './models/specificationfile';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/catch';
@@ -16,8 +16,8 @@ export class ServiceStore {
   constructor(private http: HttpClient) {
   }
 
-  public getServices(): Observable<Service[]> {
-    return this.http.get<Service[]>(this.urlRoot)
+  public getServices(): Observable<Page<Service>> {
+    return this.http.get<Page<Service>>(this.urlRoot)
       .catch((error: any) => throwError(error || 'Server error'));
   }
 

--- a/frontend/src/app/service-store.service.ts
+++ b/frontend/src/app/service-store.service.ts
@@ -18,7 +18,6 @@ export class ServiceStore {
 
   public getPage(pageNumber: number): Observable<Page<Service>> {
     const params = new HttpParams().set("page", pageNumber.toString());
-    console.log("call");
     return this.http.get<Page<Service>>(this.urlRoot, {params: params})
       .catch((error: any) => throwError(error || 'Server error'));
   }

--- a/frontend/src/app/specification-overview/specification-overview.component.css
+++ b/frontend/src/app/specification-overview/specification-overview.component.css
@@ -2,6 +2,10 @@ button {
   margin-right: 5px;
 }
 
+.centered {
+  text-align: center;
+}
+
 #chevron-column {
   width: 5%;
 }

--- a/frontend/src/app/specification-overview/specification-overview.component.html
+++ b/frontend/src/app/specification-overview/specification-overview.component.html
@@ -1,5 +1,4 @@
 <div class="container top-buffer">
-  <button class="btn btn-light" [hidden]="!displayShowMoreButton" (click)="loadNextPage()">Show more</button>
   <div class="row top-buffer">
     <div class="alert alert-danger" role="alert" *ngIf="error">
       {{ error }}
@@ -74,6 +73,9 @@
           </tbody>
         </ng-container>
       </table>
+      <div class="centered">
+        <button class="btn btn-light" [hidden]="!displayShowMoreButton" (click)="loadNextPage()">Show more</button>
+      </div>
     </div>
   </div>
 </div>

--- a/frontend/src/app/specification-overview/specification-overview.component.html
+++ b/frontend/src/app/specification-overview/specification-overview.component.html
@@ -1,5 +1,5 @@
 <div class="container top-buffer">
-  <button class="btn btn-light" (click)="loadNextPage()">Load next</button>
+  <button class="btn btn-light" [hidden]="!displayShowMoreButton" (click)="loadNextPage()">Show more</button>
   <div class="row top-buffer">
     <div class="alert alert-danger" role="alert" *ngIf="error">
       {{ error }}

--- a/frontend/src/app/specification-overview/specification-overview.component.html
+++ b/frontend/src/app/specification-overview/specification-overview.component.html
@@ -74,7 +74,7 @@
         </ng-container>
       </table>
       <div class="centered">
-        <button class="btn btn-light" [hidden]="!displayShowMoreButton" (click)="loadNextPage()">Show more</button>
+        <button class="btn btn-light" [hidden]="!morePagesExist" (click)="loadNextPage()">Show more</button>
       </div>
     </div>
   </div>

--- a/frontend/src/app/specification-overview/specification-overview.component.html
+++ b/frontend/src/app/specification-overview/specification-overview.component.html
@@ -20,7 +20,7 @@
 
   </div>
   <div class="row top-buffer">
-    <div class="col">
+    <div class="col" #serviceTable>
       <table class="table">
         <thead class="thead">
         <tr>

--- a/frontend/src/app/specification-overview/specification-overview.component.html
+++ b/frontend/src/app/specification-overview/specification-overview.component.html
@@ -1,4 +1,5 @@
 <div class="container top-buffer">
+  <button class="btn btn-light" (click)="loadNextPage()">Load next</button>
   <div class="row top-buffer">
     <div class="alert alert-danger" role="alert" *ngIf="error">
       {{ error }}

--- a/frontend/src/app/specification-overview/specification-overview.component.ts
+++ b/frontend/src/app/specification-overview/specification-overview.component.ts
@@ -33,11 +33,13 @@ const pointingDown = {
   ]
 })
 export class SpecificationOverviewComponent implements OnInit {
-  services: Service[] = [];
   error: string;
+
+  services: Service[] = [];
   expanded: string[] = [];
-  displayShowMoreButton: boolean = false;
+
   pageNumber = -1;
+  displayShowMoreButton = false;
 
   downloadFileFormatOptions: string[] = ['json', 'yaml'];
   selectedFormat: string = this.downloadFileFormatOptions[0];

--- a/frontend/src/app/specification-overview/specification-overview.component.ts
+++ b/frontend/src/app/specification-overview/specification-overview.component.ts
@@ -187,7 +187,6 @@ export class SpecificationOverviewComponent implements OnInit {
           return service;
         });
 
-        console.log(data.last);
         return {services, isLast: data.last};
       },
       error => {

--- a/frontend/src/app/specification-overview/specification-overview.component.ts
+++ b/frontend/src/app/specification-overview/specification-overview.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import {ServiceStore} from '../service-store.service';
-import {Service} from '../models/service';
 import {ApiLanguage, ReleaseType, Specification} from '../models/specification';
+import {Page, Service} from '../models/service';
 import {SpecificationStore} from '../specification-store.service';
 import {Title} from '@angular/platform-browser';
 import {animate, state, style, transition, trigger} from '@angular/animations';
@@ -146,13 +146,14 @@ export class SpecificationOverviewComponent implements OnInit {
 
   private async getServices() {
     this.serviceStore.getServices().subscribe(
-     (data: Service[]) => {
+     (data: Page<Service>) => {
        data
+         .content
          .map(element =>
            // An explicit constructor is required to use the Service class methods
            new Service(element.id, element.title, element.description, element.specifications, element.remoteAddress))
          .forEach(service => service.sortVersionsSemantically());
-       this.services = data;
+       this.services = data.content;
      },
      error1 => {
        if (error1.status === 403) {

--- a/frontend/src/app/specification-overview/specification-overview.component.ts
+++ b/frontend/src/app/specification-overview/specification-overview.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, ElementRef, HostListener, OnInit, ViewChild} from '@angular/core';
 import {ServiceStore} from '../service-store.service';
 import {ApiLanguage, ReleaseType, Specification} from '../models/specification';
 import {Page, PageOfServices, Service} from '../models/service';
@@ -34,6 +34,7 @@ const pointingDown = {
 })
 export class SpecificationOverviewComponent implements OnInit {
   error: string;
+  windowInnerHeight: number;
 
   services: Service[] = [];
   expanded: string[] = [];
@@ -44,6 +45,24 @@ export class SpecificationOverviewComponent implements OnInit {
   downloadFileFormatOptions: string[] = ['json', 'yaml'];
   selectedFormat: string = this.downloadFileFormatOptions[0];
 
+  @ViewChild('serviceTable')
+  serviceTable: ElementRef;
+
+  @HostListener('window:scroll', ['$event'])
+  onscroll() {
+    const element = this.serviceTable.nativeElement;
+    const totalTableHeight = element.scrollHeight;
+    const distanceToTopOfViewport = element.getBoundingClientRect().top;
+    const viewportHeight = this.windowInnerHeight;
+    const reachedEndOfTable = viewportHeight - distanceToTopOfViewport > totalTableHeight;
+    console.log(reachedEndOfTable);
+  }
+
+  @HostListener('window:resize', ['$event'])
+  onResize() {
+    this.windowInnerHeight = window.innerHeight;
+  }
+
   constructor(private serviceStore: ServiceStore,
               private specificationStore: SpecificationStore,
               private title: Title) {
@@ -52,6 +71,7 @@ export class SpecificationOverviewComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadNextPage();
+    this.windowInnerHeight = window.innerHeight;
   }
 
   public async deleteService(service: Service) {

--- a/frontend/src/app/specification-overview/specification-overview.component.ts
+++ b/frontend/src/app/specification-overview/specification-overview.component.ts
@@ -67,8 +67,16 @@ export class SpecificationOverviewComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.loadNextPage();
     this.windowInnerHeight = window.innerHeight;
+    this.loadInitialPages();
+  }
+
+  private loadInitialPages() {
+    if (this.reachedEndOfTable()) {
+      this.loadNextPage();
+      setTimeout(() => this.loadInitialPages(), 200);
+      // Some delay required, or else the document sizing won't have time to adjust between calls, resulting in an infinite loop
+    }
   }
 
   private reachedEndOfTable(): boolean {
@@ -76,7 +84,8 @@ export class SpecificationOverviewComponent implements OnInit {
     const totalTableHeight = element.scrollHeight;
     const distanceToTopOfViewport = element.getBoundingClientRect().top;
     const viewportHeight = this.windowInnerHeight;
-    return viewportHeight - distanceToTopOfViewport >= totalTableHeight;
+    const gapHeight = viewportHeight - distanceToTopOfViewport - totalTableHeight;
+    return gapHeight >= 0;
   }
 
   public async deleteService(service: Service) {

--- a/frontend/src/tsconfig.spec.json
+++ b/frontend/src/tsconfig.spec.json
@@ -7,6 +7,11 @@
     "types": [
       "jasmine",
       "node"
+    ],
+    "lib": [
+      "es2017",
+      "dom",
+      "esnext"
     ]
   },
   "files": [


### PR DESCRIPTION
Demo where the page size was set to 1 for a total of 3 services in the database
![paging](https://user-images.githubusercontent.com/6897716/60645175-4edd6480-9e38-11e9-8559-bd8e4daa4e37.gif)

---
Update: Load pages on scroll (Again, page size is 1)

![paging-scroll](https://user-images.githubusercontent.com/6897716/60716845-b078fe00-9f20-11e9-91de-c495f491b19c.gif)
---
In `application.properties`, the user can set the page size with `apicenter.pageSize=N`, where it defaults to 10.