### PR TITLE
Upload with service id in resource path

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -32,6 +32,7 @@ const appRoutes: Routes = [
   {path: 'specifications/:serviceId/:version', component: SpecificationViewComponent, canActivate: [AuthenticationGuard]},
   {path: 'diff/:serviceId', component: DiffVersionsComponent, canActivate: [AuthenticationGuard]},
   {path: 'add-specifications', component: SpecificationFormComponent, canActivate: [AuthenticationGuard]},
+  {path: 'edit-specifications/:serviceId', component: SpecificationFormComponent, canActivate: [AuthenticationGuard]},
   {path: 'search', component: SpecificationSearchDetailComponent, canActivate: [AuthenticationGuard]},
   {path: 'search/:searchString', component: SpecificationSearchDetailComponent, canActivate: [AuthenticationGuard]},
   {path: 'login', component: LoginComponent}

--- a/frontend/src/app/models/specificationfile.ts
+++ b/frontend/src/app/models/specificationfile.ts
@@ -3,21 +3,21 @@ import {ApiLanguage} from './specification';
 export interface SpecificationMetadata {
   title: string;
   version: string;
-  description: string;
+  description?: string;
   language: ApiLanguage;
-  endpointUrl: string;
+  endpointUrl?: string;
 }
 
 export class SpecificationFile {
   metadata?: SpecificationMetadata;
   fileContent: string;
   fileUrl: string;
+  id?: string;
 
-  constructor(fileContent: string, fileUrl: string, metadata?: SpecificationMetadata) {
+  constructor(fileContent: string, fileUrl: string, id?: string, metadata?: SpecificationMetadata) {
     this.fileContent = fileContent;
     this.fileUrl = fileUrl;
-    if (metadata) {
-      this.metadata = metadata;
-    }
+    this.id = id;
+    this.metadata = metadata;
   }
 }

--- a/frontend/src/app/specification-form/specification-form.component.html
+++ b/frontend/src/app/specification-form/specification-form.component.html
@@ -24,14 +24,18 @@
          <p>
            For a GraphQL specification, ApiCenter needs some additional metadata:
          </p>
-         <div *ngFor="let fieldName of objectKeys(additionalFields)">
+         <div *ngFor="let fieldName of objectKeys({
+                                          title: additionalFields.title,
+                                          version: additionalFields.version,
+                                          description: additionalFields.description
+                                          })">
            <input type="text"
                   [placeholder]="fieldName.charAt(0).toUpperCase() + fieldName.slice(1)"
                   [(ngModel)]="additionalFields[fieldName]"/>
          </div>
          <hr>
          <p>Test API endpoint, where sample requests can be sent:</p>
-         <input type="text" placeholder="URL" [(ngModel)]="endpointUrl"/>
+         <input type="text" placeholder="URL" [(ngModel)]="additionalFields.endpointUrl"/>
        </div>
     </div>
 

--- a/frontend/src/app/specification-form/specification-form.component.ts
+++ b/frontend/src/app/specification-form/specification-form.component.ts
@@ -40,8 +40,8 @@ export class SpecificationFormComponent implements OnInit {
   error: string;
   specificationFiles: File[];
   remoteFileUrl: string;
-  additionalFields = {title: '', version: '', description: ''};
-  endpointUrl = '';
+  additionalFields = {title: '', version: '', description: '', endpointUrl: ''};
+  id?: string;
   showAdditionalMetadataFields = false;
   objectKeys = Object.keys;
 
@@ -53,10 +53,8 @@ export class SpecificationFormComponent implements OnInit {
 
   ngOnInit() {
     this.route.params.subscribe(params => {
-      if (params['id']) {
-        this.serviceStore.getService(params['id']).subscribe((service: Service) => {
-          this.remoteFileUrl = service.remoteAddress;
-        });
+      if (params['serviceId']) {
+        this.id = params['serviceId'];
       }
     });
   }
@@ -130,9 +128,9 @@ export class SpecificationFormComponent implements OnInit {
       reader.onload = function () {
         const fileContent = reader.result.toString();
         const metadata: SpecificationMetadata = me.showAdditionalMetadataFields ?
-          {...me.additionalFields, language: ApiLanguage.GraphQL, endpointUrl: me.endpointUrl}
+          {...me.additionalFields, language: ApiLanguage.GraphQL}
           : null;
-        const file = new SpecificationFile(fileContent, null, metadata);
+        const file = new SpecificationFile(fileContent, null, me.id, metadata);
         me.createSpecifications([file]);
       };
 
@@ -142,7 +140,7 @@ export class SpecificationFormComponent implements OnInit {
 
   private handleRemoteFile() {
     this.createSpecifications([
-      new SpecificationFile(null, this.remoteFileUrl, null)
+      new SpecificationFile(null, this.remoteFileUrl, this.id, null)
     ]);
   }
 
@@ -167,7 +165,7 @@ export class SpecificationFormComponent implements OnInit {
 
         temporaryFileReader.onload = () => {
           const text = temporaryFileReader.result.toString();
-          const dto = new SpecificationFile(text, null, null);
+          const dto = new SpecificationFile(text, null, this.id, null);
           resolve(dto);
         };
 

--- a/frontend/src/app/specification-overview/specification-overview.component.html
+++ b/frontend/src/app/specification-overview/specification-overview.component.html
@@ -49,6 +49,8 @@
               <button class="btn oi oi-loop-circular" title="Check for updates" *ngIf="service.remoteAddress != null"
                       (click)="synchronize(service)"></button>
               <button class="btn oi oi-layers" title="Compare versions in detail" [routerLink]="['diff', service.id]"></button>
+              <button class="btn oi oi-data-transfer-upload" title="Upload a new version of this specification"
+                      [routerLink]="['edit-specifications', service.id]"></button>
               <button class="btn oi oi-data-transfer-download" title="Download" (click)="downloadService(service, selectedFormat)"></button>
               <button class="btn oi oi-trash" title="Delete" (click)="deleteService(service)"></button>
             </td>


### PR DESCRIPTION
New versions can be uploaded without requiring `x-api-id` or a manually supplied id.

"id" was already an optional field in the `SpecificationFileDto` backend object. (Some integration tests use it.) This just populates it correctly in the frontend, when the user clicks on the upload button associated with a certain service.